### PR TITLE
EXS-122 - Fix required versions for sw dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "shopware/core": "~6.5",
-        "shopware/administration": "~6.5"
+        "shopware/core": "~6.5.0",
+        "shopware/administration": "~6.5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Solution to the following error:

> Basic plugin analysis failed.
> 
> The information provided in the composer.json file is invalid
> Context: [
>  • required.shopware/core#mismatch: The compatibility in your composer.json "required"."shopware/core" was set to Version ~6.5 These versions are missing in your account to fulfill this requirement: 6.6.0.0, 6.6.0.2, 6.6.0.3, 6.6.1.0, 6.6.1.1, 6.6.1.2, 6.6.2.0, 6.6.3.0
> ]
> Documentation: https://docs.shopware.com/en/shopware-platform-dev-en/references-internals/plugins/plugin-information?category=shopware-platform-dev-en/references-internals/plugins
