### PR TITLE
NEXT-39412 - Fix PHPStan issue in IAP and adjust code style

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,13 +14,16 @@ on:
     - cron: '0 3 * * *'
 jobs:
   cs:
-    if: github.event_name != 'schedule'
     uses: shopware/github-actions/.github/workflows/cs-fixer.yml@main
+    with:
+      rules: ''
+
   phpstan:
     uses: shopware/github-actions/.github/workflows/phpstan.yml@main
     with:
       extensionName: ${{ github.event.repository.name }}
       shopwareVersion: trunk
+
   phpunit:
     uses: shopware/github-actions/.github/workflows/phpunit.yml@main
     with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+use Symfony\Component\Filesystem\Path;
+
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+
+        'blank_line_after_opening_tag' => false,
+        'class_attributes_separation' => ['elements' => ['property' => 'one', 'method' => 'one']],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'fopen_flags' => false,
+        'general_phpdoc_annotation_remove' => ['annotations' => ['copyright', 'category']],
+        'linebreak_after_opening_tag' => false,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'native_function_invocation' => [
+            'scope' => 'namespaced',
+            'strict' => false,
+            'exclude' => ['ini_get'],
+        ],
+        'no_superfluous_phpdoc_tags' => ['allow_unused_params' => true, 'allow_mixed' => true],
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'phpdoc_align' => ['align' => 'left'],
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_line_span' => true,
+        'phpdoc_order' => ['order' => ['param', 'throws', 'return']],
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => false,
+        'php_unit_dedicate_assert' => ['target' => 'newest'],
+        'php_unit_dedicate_assert_internal_type' => true,
+        'php_unit_mock' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'static'],
+        'self_accessor' => false,
+        'single_line_throw' => false,
+        'single_quote' => ['strings_containing_single_quote_chars' => true],
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match']],
+        'void_return' => true,
+        'yoda_style' => [
+            'equal' => false,
+            'identical' => false,
+            'less_and_greater' => false,
+        ],
+    ])
+    ->setUsingCache(true)
+    ->setCacheFile(Path::join($_SERVER['SHOPWARE_TOOL_CACHE_ECS'] ?? __DIR__, '/var/cache/php-cs-fixer.cache'))
+    ->setFinder(
+        (new Finder())
+            ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+            ->exclude(['node_modules', '*/vendor/*', 'var/cache'])
+    );

--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,11 @@
         }
     },
     "scripts": {
-        "cs-fixer-dry": [
-            "@php ../../../vendor/bin/php-cs-fixer fix . --dry-run --rules=@PER-CS2.0,no_unused_imports"
+        "cs": [
+            "@php ../../../vendor/bin/php-cs-fixer fix --dry-run"
         ],
-        "cs-fixer": [
-            "@php ../../../vendor/bin/php-cs-fixer fix . --rules=@PER-CS2.0,no_unused_imports"
+        "cs-fix": [
+            "@php ../../../vendor/bin/php-cs-fixer fix"
         ],
         "phpstan": [
             "@php ../../../src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",

--- a/src/Controller/InAppPurchasesController.php
+++ b/src/Controller/InAppPurchasesController.php
@@ -39,7 +39,8 @@ class InAppPurchasesController
         private readonly AbstractExtensionDataProvider $extensionDataProvider,
         private readonly InAppPurchasesGateway $appPurchasesGateway,
         private readonly EntityRepository $appRepository,
-    ) {}
+    ) {
+    }
 
     #[Route('/api/_action/in-app-purchases/{technicalName}/details', name: 'api.in-app-purchases.detail', methods: ['GET'])]
     public function getInAppFeature(string $technicalName, Context $context): Response
@@ -68,8 +69,9 @@ class InAppPurchasesController
     #[Route('/api/_action/in-app-purchases/cart/order', name: 'api.in-app-purchases.cart.order', methods: ['POST'])]
     public function orderCart(RequestDataBag $data, Context $context): Response
     {
-        $taxRate = \floatval($data->getString('taxRate'));
+        $taxRate = (float) $data->getString('taxRate');
         $positions = $data->get('positions');
+        \assert($positions instanceof RequestDataBag);
         $extensionName = $data->get('name');
 
         $positionCollection = InAppPurchaseCartPositionCollection::fromArray($positions->all());
@@ -122,7 +124,7 @@ class InAppPurchasesController
     #[Route('/api/_action/in-app-purchases/refresh', name: 'api.in-app-purchase.refresh', methods: ['GET'])]
     public function refreshInAppPurchases(Context $context): Response
     {
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) {
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context): void {
             $this->inAppPurchaseUpdater->update($context);
         });
 

--- a/src/Services/InAppPurchasesService.php
+++ b/src/Services/InAppPurchasesService.php
@@ -18,8 +18,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class InAppPurchasesService
 {
     public function __construct(
-        private StoreClient $client,
-    ) {}
+        private readonly StoreClient $client,
+    ) {
+    }
 
     public function createCart(string $extensionName, string $feature, Context $context): InAppPurchaseCartStruct
     {

--- a/src/Services/StoreClient.php
+++ b/src/Services/StoreClient.php
@@ -42,7 +42,8 @@ class StoreClient
         private readonly array $endpoints,
         private readonly AbstractStoreRequestOptionsProvider $storeRequestOptionsProvider,
         private readonly ClientInterface $client,
-    ) {}
+    ) {
+    }
 
     /**
      * @return array{headers: ResponseHeaders, data: list<ExtensionInfo>}
@@ -99,7 +100,7 @@ class StoreClient
         try {
             $response = $this->client->request(
                 'GET',
-                sprintf($this->endpoints['extension_detail'], $id),
+                \sprintf($this->endpoints['extension_detail'], $id),
                 [
                     'query' => $this->storeRequestOptionsProvider->getDefaultQueryParameters($context),
                     'headers' => $this->storeRequestOptionsProvider->getAuthenticationHeader($context),
@@ -126,7 +127,7 @@ class StoreClient
         try {
             $response = $this->client->request(
                 'GET',
-                sprintf($this->endpoints['reviews'], $id),
+                \sprintf($this->endpoints['reviews'], $id),
                 [
                     'query' => array_merge($this->storeRequestOptionsProvider->getDefaultQueryParameters($context), $criteria->getQueryParameter()),
                     'headers' => $this->storeRequestOptionsProvider->getAuthenticationHeader($context),

--- a/src/Struct/InAppPurchaseCartPositionCollection.php
+++ b/src/Struct/InAppPurchaseCartPositionCollection.php
@@ -22,7 +22,7 @@ class InAppPurchaseCartPositionCollection extends Collection
      */
     public static function fromArray(array $data): self
     {
-        $elements = \array_map(static fn(array $element) => InAppPurchaseCartPositionStruct::fromArray($element), $data);
+        $elements = \array_map(static fn (array $element) => InAppPurchaseCartPositionStruct::fromArray($element), $data);
 
         return new self($elements);
     }
@@ -37,17 +37,12 @@ class InAppPurchaseCartPositionCollection extends Collection
         }, $this->elements); // @phpstan-ignore-line property.deprecated will be strictly typed. Remove this ignore for shopware v6.7.0
     }
 
-    protected function getExpectedClass(): ?string
-    {
-        return InAppPurchaseCartPositionStruct::class;
-    }
-
     /**
      * @return array<int, string>
      */
     public function getIdentifiers(): array
     {
-        return $this->map(static fn(InAppPurchaseCartPositionStruct $element) => $element->getInAppFeatureIdentifier());
+        return $this->map(static fn (InAppPurchaseCartPositionStruct $element) => $element->getInAppFeatureIdentifier());
     }
 
     /**
@@ -58,7 +53,12 @@ class InAppPurchaseCartPositionCollection extends Collection
         array $validPurchases,
     ): self {
         return $allPurchases->filter(function (InAppPurchaseCartPositionStruct $purchase) use ($validPurchases) {
-            return \in_array($purchase->getInAppFeatureIdentifier(), $validPurchases);
+            return \in_array($purchase->getInAppFeatureIdentifier(), $validPurchases, true);
         });
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return InAppPurchaseCartPositionStruct::class;
     }
 }

--- a/src/Struct/InAppPurchaseCartPositionStruct.php
+++ b/src/Struct/InAppPurchaseCartPositionStruct.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Struct\Struct;
  *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePriceModel from InAppPurchasePriceModelStruct
+ *
  * @phpstan-type InAppPurchaseCartPosition array{extensionName: string, inAppFeatureIdentifier: string, netPrice: float, grossPrice: float, taxRate: float, taxValue: float}
  */
 #[Package('checkout')]
@@ -24,7 +25,8 @@ class InAppPurchaseCartPositionStruct extends Struct
         protected float $grossPrice = 0.0,
         protected float $taxRate = 0.0,
         protected float $taxValue = 0.0,
-    ) {}
+    ) {
+    }
 
     /**
      * @param InAppPurchaseCartPosition $data

--- a/src/Struct/InAppPurchaseCartStruct.php
+++ b/src/Struct/InAppPurchaseCartStruct.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Struct\Struct;
  * @codeCoverageIgnore
  *
  * @phpstan-import-type InAppPurchaseCartPosition from InAppPurchaseCartPositionStruct
+ *
  * @phpstan-type Shop array{id: int, domain: string}|array{}
  * @phpstan-type InAppPurchaseCart array{positions: InAppPurchaseCartPosition[], bookingShop: Shop, licenseShop: Shop, netPrice: float, grossPrice: float, taxRate: float, taxValue: float}
  */
@@ -29,7 +30,8 @@ class InAppPurchaseCartStruct extends Struct
         protected float $grossPrice = 0.0,
         protected float $taxRate = 0.0,
         protected float $taxValue = 0.0,
-    ) {}
+    ) {
+    }
 
     /**
      * @param InAppPurchaseCart $data

--- a/src/Struct/InAppPurchaseCollection.php
+++ b/src/Struct/InAppPurchaseCollection.php
@@ -22,7 +22,7 @@ class InAppPurchaseCollection extends Collection
      */
     public static function fromArray(array $data): self
     {
-        $elements = \array_map(static fn(array $element) => InAppPurchaseStruct::fromArray($element), $data);
+        $elements = \array_map(static fn (array $element) => InAppPurchaseStruct::fromArray($element), $data);
 
         return new self($elements);
     }
@@ -32,7 +32,7 @@ class InAppPurchaseCollection extends Collection
      */
     public function getIdentifiers(): array
     {
-        return $this->map(static fn(InAppPurchaseStruct $element) => $element->getIdentifier());
+        return $this->map(static fn (InAppPurchaseStruct $element) => $element->getIdentifier());
     }
 
     /**
@@ -43,7 +43,7 @@ class InAppPurchaseCollection extends Collection
         array $validPurchases,
     ): InAppPurchaseCollection {
         return $allPurchases->filter(function (InAppPurchaseStruct $purchase) use ($validPurchases) {
-            return \in_array($purchase->getIdentifier(), $validPurchases);
+            return \in_array($purchase->getIdentifier(), $validPurchases, true);
         });
     }
 }

--- a/src/Struct/InAppPurchasePriceModelCollection.php
+++ b/src/Struct/InAppPurchasePriceModelCollection.php
@@ -22,7 +22,7 @@ class InAppPurchasePriceModelCollection extends Collection
      */
     public static function fromArray(array $data): self
     {
-        $elements = \array_map(static fn(array $element) => InAppPurchasePriceModelStruct::fromArray($element), $data);
+        $elements = \array_map(static fn (array $element) => InAppPurchasePriceModelStruct::fromArray($element), $data);
 
         return new self($elements);
     }

--- a/src/Struct/InAppPurchasePriceModelStruct.php
+++ b/src/Struct/InAppPurchasePriceModelStruct.php
@@ -20,7 +20,8 @@ class InAppPurchasePriceModelStruct extends Struct
         protected float $price = 0.0,
         protected ?string $duration = null,
         protected ?bool $oneTimeOnly = null,
-    ) {}
+    ) {
+    }
 
     /**
      * @param InAppPurchasePriceModel $data

--- a/src/Struct/InAppPurchaseStruct.php
+++ b/src/Struct/InAppPurchaseStruct.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Struct\Struct;
  * @codeCoverageIgnore
  *
  * @phpstan-import-type InAppPurchasePriceModel from InAppPurchasePriceModelStruct
+ *
  * @phpstan-type InAppPurchase array{identifier: string, name: string, description: string|null, priceModel: InAppPurchasePriceModel}
  */
 #[Package('checkout')]
@@ -21,7 +22,8 @@ class InAppPurchaseStruct extends Struct
         protected string $identifier = '',
         protected string $name = '',
         protected ?string $description = null,
-    ) {}
+    ) {
+    }
 
     /**
      * @param InAppPurchase $data

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -140,8 +140,8 @@ class InAppPurchasesControllerTest extends TestCase
 
     public function testOrderCartWithInvalidItem(): void
     {
-        static::expectException(ExtensionStoreException::class);
-        static::expectExceptionMessage('The in-app purchase could not be completed. Please contact the extension provider.');
+        $this->expectException(ExtensionStoreException::class);
+        $this->expectExceptionMessage('The in-app purchase could not be completed. Please contact the extension provider.');
 
         $service = $this->createMock(InAppPurchasesService::class);
         $service->expects(static::never())
@@ -274,7 +274,7 @@ class InAppPurchasesControllerTest extends TestCase
             $this->createMock(EntityRepository::class),
         );
 
-        $content = $this->validateResponse($controller->refreshInAppPurchases($context), Response::HTTP_NO_CONTENT);
+        $this->validateResponse($controller->refreshInAppPurchases($context), Response::HTTP_NO_CONTENT);
     }
 
     private function getInAppPurchaseCartStruct(): InAppPurchaseCartStruct
@@ -317,7 +317,7 @@ class InAppPurchasesControllerTest extends TestCase
     }
 
     /**
-     * @return array<mixed> $response
+     * @return array<string, mixed> $response
      */
     private function validateResponse(Response $response, int $statusCode = Response::HTTP_OK): array
     {

--- a/tests/Services/StoreClientTest.php
+++ b/tests/Services/StoreClientTest.php
@@ -156,6 +156,7 @@ class StoreClientTest extends TestCase
             $iapJson = file_get_contents(__DIR__ . '/../_fixtures/responses/extension-iap.json');
             static::assertIsString($iapJson);
             $requestHandler->append(new Response($statusCode, [], $iapJson));
+
             return;
         }
         $requestHandler->append(new Response($statusCode, []));

--- a/tests/Struct/InAppPurchaseCartPositionCollectionTest.php
+++ b/tests/Struct/InAppPurchaseCartPositionCollectionTest.php
@@ -16,23 +16,21 @@ class InAppPurchaseCartPositionCollectionTest extends TestCase
     {
         $collection = $this->getAppPurchaseCartPositionCollection();
 
-        self::assertCount(2, $collection);
+        static::assertCount(2, $collection);
     }
 
     public function testToCartReturnsCorrectCartArray(): void
     {
-        $collection = $this->getAppPurchaseCartPositionCollection();
+        $cart = $this->getAppPurchaseCartPositionCollection()->toCart();
 
-        $cart = $collection->toCart();
-
-        self::assertCount(2, $cart);
-        self::assertSame('feature_1', $cart[0]['inAppFeatureIdentifier']);
-        self::assertSame('feature_2', $cart[1]['inAppFeatureIdentifier']);
+        static::assertCount(2, $cart);
+        static::assertSame('feature_1', $cart[0]['inAppFeatureIdentifier']);
+        static::assertSame('feature_2', $cart[1]['inAppFeatureIdentifier']);
     }
 
     public function testGetIdentifiersReturnsCorrectIdentifiers(): void
     {
-        self::assertSame(['feature_1', 'feature_2'], $this->getAppPurchaseCartPositionCollection()->getIdentifiers());
+        static::assertSame(['feature_1', 'feature_2'], $this->getAppPurchaseCartPositionCollection()->getIdentifiers());
     }
 
     public function testFilterValidInAppPurchasesReturnsValidPurchases(): void
@@ -43,10 +41,10 @@ class InAppPurchaseCartPositionCollectionTest extends TestCase
 
         $filteredCollection = $allPurchases->filterValidInAppPurchases($allPurchases, $validPurchases);
 
-        self::assertCount(1, $filteredCollection);
+        static::assertCount(1, $filteredCollection);
         $first = $filteredCollection->first();
-        self::assertInstanceOf(InAppPurchaseCartPositionStruct::class, $first);
-        self::assertSame('feature_1', $first->getInAppFeatureIdentifier());
+        static::assertInstanceOf(InAppPurchaseCartPositionStruct::class, $first);
+        static::assertSame('feature_1', $first->getInAppFeatureIdentifier());
     }
 
     public function getAppPurchaseCartPositionCollection(): InAppPurchaseCartPositionCollection

--- a/tests/Struct/InAppPurchaseCollectionTest.php
+++ b/tests/Struct/InAppPurchaseCollectionTest.php
@@ -16,16 +16,14 @@ class InAppPurchaseCollectionTest extends TestCase
     {
         $collection = $this->getInAppPurchaseCollection();
 
-        self::assertCount(2, $collection);
+        static::assertCount(2, $collection);
     }
 
     public function testGetIdentifiers(): void
     {
-        $collection = $this->getInAppPurchaseCollection();
+        $identifiers = $this->getInAppPurchaseCollection()->getIdentifiers();
 
-        $identifiers = $collection->getIdentifiers();
-
-        self::assertSame(['purchase_1', 'purchase_2'], $identifiers);
+        static::assertSame(['purchase_1', 'purchase_2'], $identifiers);
     }
 
     public function testFilterValidInAppPurchases(): void
@@ -36,40 +34,40 @@ class InAppPurchaseCollectionTest extends TestCase
 
         $filteredCollection = $allPurchases->filterValidInAppPurchases($allPurchases, $validPurchases);
 
-        self::assertCount(1, $filteredCollection);
+        static::assertCount(1, $filteredCollection);
         $first = $filteredCollection->first();
-        self::assertInstanceOf(InAppPurchaseStruct::class, $first);
-        self::assertSame('purchase_1', $first->getIdentifier());
+        static::assertInstanceOf(InAppPurchaseStruct::class, $first);
+        static::assertSame('purchase_1', $first->getIdentifier());
 
         $validPurchases = ['non_existent_purchase'];
 
         $filteredCollection = $allPurchases->filterValidInAppPurchases($allPurchases, $validPurchases);
 
-        self::assertCount(0, $filteredCollection);
+        static::assertCount(0, $filteredCollection);
 
         $validPurchases = ['purchase_1', 'purchase_2'];
 
         $filteredCollection = $allPurchases->filterValidInAppPurchases($allPurchases, $validPurchases);
 
-        self::assertCount(2, $filteredCollection);
+        static::assertCount(2, $filteredCollection);
         $first = $filteredCollection->first();
-        self::assertInstanceOf(InAppPurchaseStruct::class, $first);
-        self::assertSame('purchase_1', $first->getIdentifier());
+        static::assertInstanceOf(InAppPurchaseStruct::class, $first);
+        static::assertSame('purchase_1', $first->getIdentifier());
         $last = $filteredCollection->last();
-        self::assertInstanceOf(InAppPurchaseStruct::class, $last);
-        self::assertSame('purchase_2', $last->getIdentifier());
+        static::assertInstanceOf(InAppPurchaseStruct::class, $last);
+        static::assertSame('purchase_2', $last->getIdentifier());
 
         $validPurchases = ['purchase_1', 'purchase_2', 'purchase_3'];
 
         $filteredCollection = $allPurchases->filterValidInAppPurchases($allPurchases, $validPurchases);
 
-        self::assertCount(2, $filteredCollection);
+        static::assertCount(2, $filteredCollection);
         $first = $filteredCollection->first();
-        self::assertInstanceOf(InAppPurchaseStruct::class, $first);
-        self::assertSame('purchase_1', $first->getIdentifier());
+        static::assertInstanceOf(InAppPurchaseStruct::class, $first);
+        static::assertSame('purchase_1', $first->getIdentifier());
         $last = $filteredCollection->last();
-        self::assertInstanceOf(InAppPurchaseStruct::class, $last);
-        self::assertSame('purchase_2', $last->getIdentifier());
+        static::assertInstanceOf(InAppPurchaseStruct::class, $last);
+        static::assertSame('purchase_2', $last->getIdentifier());
     }
 
     public function getInAppPurchaseCollection(): InAppPurchaseCollection

--- a/tests/_fixtures/AppStoreTestPlugin/src/AppStoreTestPlugin.php
+++ b/tests/_fixtures/AppStoreTestPlugin/src/AppStoreTestPlugin.php
@@ -6,4 +6,6 @@ namespace AppStoreTestPlugin;
 
 use Shopware\Core\Framework\Plugin;
 
-class AppStoreTestPlugin extends Plugin {}
+class AppStoreTestPlugin extends Plugin
+{
+}


### PR DESCRIPTION
@lernhart just FYI: I executed some tests locally and got deprecation messages about dynamic properties. This will blow up with PHP9 :wink: 

```
  6x: Creation of dynamic property SwagExtensionStore\Struct\InAppPurchaseStruct::$extensionName is deprecated
    3x in InAppPurchasesControllerTest::testListPurchasesWithInvalidItems from SwagExtensionStore\Tests\Controller
    3x in InAppPurchasesControllerTest::testListPurchasesWithValidItems from SwagExtensionStore\Tests\Controller

  1x: Creation of dynamic property SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct::$priceModel is deprecated
    1x in InAppPurchasesControllerTest::testCreateCart from SwagExtensionStore\Tests\Controller

  1x: Creation of dynamic property SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct::$feature is deprecated
    1x in InAppPurchasesControllerTest::testCreateCart from SwagExtensionStore\Tests\Controller
```