### PR TITLE
[6.6.x] fix: build admin in production

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 # Folders
 /.github export-ignore
 /tests export-ignore
-/src/Resources/app/administration/internal-rules export-ignore
 
 # Files
 /src/Resources/app/administration/.eslintignore export-ignore


### PR DESCRIPTION
`internal-rules` is listed as a dependency in package.json. Without including it in the production build, customers will not be able to build the administration because npm will not find it as a dependency.