### PR TITLE
feat: get only active purchases

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-in-app-purchases-listing-modal/sw-extension-store-in-app-purchases-listing-modal.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-in-app-purchases-listing-modal/sw-extension-store-in-app-purchases-listing-modal.html.twig
@@ -45,7 +45,9 @@
                 </span>
 
                 <ul class="sw-extension-store-detail-in-app-purchases-listing-modal-content__payment-options">
-                    {{ formatCurrency(inAppPurchase.priceModel.price, inAppPurchase.priceModel.currency) }}* {{ inAppPurchase.priceModel.duration }}
+                    <li v-for="(priceModel, index) in inAppPurchase.priceModels" :key="index">
+                        {{ formatCurrency(priceModel.price, priceModel.currency) }}* {{ priceModel.type === 'rent' ? priceModel.variant : $t('sw-extension-store.in-app-purchases.onceOff') }}
+                    </li>
                 </ul>
             </template>
         </sw-collapse>

--- a/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-in-app-purchases-listing-modal/sw-extension-store-in-app-purchases-listing-modal.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-in-app-purchases-listing-modal/sw-extension-store-in-app-purchases-listing-modal.spec.js
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils';
+
+Shopware.Component.register(
+    'sw-extension-store-in-app-purchases-listing-modal',
+    () => import('SwagExtensionStore/module/sw-extension-store/component/sw-extension-store-in-app-purchases-listing-modal'),
+);
+
+async function createWrapper(propsData = {}) {
+    return mount(await Shopware.Component.build('sw-extension-store-in-app-purchases-listing-modal'), {
+        props: {
+            extension: propsData.extension || { name: 'Test Extension' },
+            inAppPurchases: propsData.inAppPurchases || [],
+        },
+        global: {
+            stubs: {
+                'sw-modal': {
+                    template: `<div class="sw-modal"><slot></slot><slot name="modal-footer"></slot></div>`,
+                },
+                'mt-icon': true,
+                'sw-collapse': {
+                    template: `<div class="sw-collapse"><slot name="header"></slot><slot name="content"></slot></div>`,
+                },
+            },
+        },
+    });
+}
+
+describe('sw-extension-store-in-app-purchases-listing-modal', () => {
+    it('should be a Vue.js component', async () => {
+        const wrapper = await createWrapper();
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('emits "modal-close" when closeInAppPurchasesListingModal is called', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.closeInAppPurchasesListingModal();
+        expect(wrapper.emitted('modal-close')).toBeTruthy();
+    });
+
+    it('formats currency using Shopware.Utils.format.currency', async () => {
+        const wrapper = await createWrapper();
+        const result = wrapper.vm.formatCurrency(100, 'EUR');
+
+        expect(result).toBe('€100.00');
+    });
+});

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/de-DE.json
@@ -66,6 +66,9 @@
                 "paymentMeansRequiredText": "Um diese App zu kaufen, musst Du",
                 "paymentMeansRequiredLinkText": "eine Zahlungsmethode hinzufügen"
             }
+        },
+        "in-app-purchases": {
+            "onceOff": "einmalig"
         }
     },
     "sw-extension-store-statistics-promotion": {

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/en-GB.json
@@ -66,6 +66,9 @@
                 "paymentMeansRequiredText": "In order to purchase this app you'll have to",
                 "paymentMeansRequiredLinkText": "add a payment method"
             }
+        },
+        "in-app-purchases": {
+            "onceOff": "one-time"
         }
     },
     "sw-extension-store-statistics-promotion": {

--- a/src/Services/InAppPurchasesService.php
+++ b/src/Services/InAppPurchasesService.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCollection;
+use SwagExtensionStore\Struct\InAppPurchaseStatus;
 use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -40,6 +41,6 @@ class InAppPurchasesService
     {
         $purchases = $this->client->listInAppPurchases($extensionName, $context);
 
-        return $purchases->filter(fn (InAppPurchaseStruct $purchase) => $purchase->getStatus() === InAppPurchaseStruct::STATUS_ACTIVE);
+        return $purchases->filter(fn (InAppPurchaseStruct $purchase) => $purchase->getStatus() === InAppPurchaseStatus::ACTIVE);
     }
 }

--- a/src/Services/InAppPurchasesService.php
+++ b/src/Services/InAppPurchasesService.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCollection;
+use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -37,6 +38,8 @@ class InAppPurchasesService
 
     public function listPurchases(string $extensionName, Context $context): InAppPurchaseCollection
     {
-        return $this->client->listInAppPurchases($extensionName, $context);
+        $purchases = $this->client->listInAppPurchases($extensionName, $context);
+
+        return $purchases->filter(fn (InAppPurchaseStruct $purchase) => $purchase->getStatus() === InAppPurchaseStruct::STATUS_ACTIVE);
     }
 }

--- a/src/Struct/InAppPurchaseStatus.php
+++ b/src/Struct/InAppPurchaseStatus.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace SwagExtensionStore\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+enum InAppPurchaseStatus: string
+{
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}

--- a/src/Struct/InAppPurchaseStruct.php
+++ b/src/Struct/InAppPurchaseStruct.php
@@ -17,12 +17,9 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class InAppPurchaseStruct extends Struct
 {
-    public const STATUS_ACTIVE = 'active';
-    public const STATUS_INACTIVE = 'inactive';
-
     private function __construct(
         protected InAppPurchasePriceModelCollection $priceModels,
-        protected string $status = '',
+        protected InAppPurchaseStatus $status = InAppPurchaseStatus::INACTIVE,
         protected string $identifier = '',
         protected string $name = '',
         protected ?string $description = null,
@@ -104,12 +101,12 @@ class InAppPurchaseStruct extends Struct
         $this->websiteGtc = $websiteGtc;
     }
 
-    public function getStatus(): string
+    public function getStatus(): InAppPurchaseStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function setStatus(InAppPurchaseStatus $status): void
     {
         $this->status = $status;
     }

--- a/src/Struct/InAppPurchaseStruct.php
+++ b/src/Struct/InAppPurchaseStruct.php
@@ -17,8 +17,12 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class InAppPurchaseStruct extends Struct
 {
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_INACTIVE = 'inactive';
+
     private function __construct(
         protected InAppPurchasePriceModelCollection $priceModels,
+        protected string $status = '',
         protected string $identifier = '',
         protected string $name = '',
         protected ?string $description = null,
@@ -98,5 +102,15 @@ class InAppPurchaseStruct extends Struct
     public function setWebsiteGtc(?string $websiteGtc): void
     {
         $this->websiteGtc = $websiteGtc;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
     }
 }

--- a/tests/Services/InAppPurchasesServiceTest.php
+++ b/tests/Services/InAppPurchasesServiceTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace SwagExtensionStore\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use SwagExtensionStore\Services\InAppPurchasesService;
+use SwagExtensionStore\Services\StoreClient;
+use SwagExtensionStore\Struct\InAppPurchaseCollection;
+use SwagExtensionStore\Struct\InAppPurchaseStruct;
+
+class InAppPurchasesServiceTest extends TestCase
+{
+    public function testListPurchases(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $storeClientMock = $this->createMock(StoreClient::class);
+        $storeClientMock->method('listInAppPurchases')
+            ->with('testExtension', $context)
+            ->willReturn($this->getAllPurchases());
+
+        $response = (new InAppPurchasesService($storeClientMock))
+            ->listPurchases('testExtension', $context);
+
+        static::assertCount(2, $response);
+
+        $firstPurchase = $response->first();
+        static::assertInstanceOf(InAppPurchaseStruct::class, $firstPurchase);
+        static::assertSame($firstPurchase->getStatus(), InAppPurchaseStruct::STATUS_ACTIVE);
+        static::assertSame($firstPurchase->getIdentifier(), 'testFeature');
+
+        $lastPurchase = $response->last();
+        static::assertInstanceOf(InAppPurchaseStruct::class, $lastPurchase);
+        static::assertSame($lastPurchase->getStatus(), InAppPurchaseStruct::STATUS_ACTIVE);
+        static::assertSame($lastPurchase->getIdentifier(), 'testFeature2');
+    }
+
+    private function getAllPurchases(): InAppPurchaseCollection
+    {
+        return InAppPurchaseCollection::fromArray([
+            [
+                'extensionName' => 'testExtension',
+                'identifier' => 'testFeature',
+                'name' => 'Test Feature',
+                'description' => null,
+                'priceModels' => [[
+                    'variant' => 'yearly',
+                    'type' => 'rent',
+                    'price' => 59.5,
+                    'duration' => 12,
+                    'oneTimeOnly' => false,
+                    'conditionsType' => null,
+                ]],
+                'status' => InAppPurchaseStruct::STATUS_ACTIVE,
+            ], [
+                'extensionName' => 'testExtension',
+                'identifier' => 'testFeature2',
+                'name' => 'Test Feature 2',
+                'description' => null,
+                'priceModels' => [[
+                    'variant' => 'monthly',
+                    'type' => 'rent',
+                    'price' => 1.5,
+                    'duration' => 1,
+                    'oneTimeOnly' => false,
+                    'conditionsType' => null,
+                ]],
+                'status' => InAppPurchaseStruct::STATUS_ACTIVE,
+            ], [
+                'extensionName' => 'testExtension',
+                'identifier' => 'testFeature3',
+                'name' => 'Test Feature 3',
+                'description' => null,
+                'priceModels' => [[
+                    'variant' => 'monthly',
+                    'type' => 'rent',
+                    'price' => 1.5,
+                    'duration' => 1,
+                    'oneTimeOnly' => false,
+                    'conditionsType' => null,
+                ]],
+                'status' => InAppPurchaseStruct::STATUS_INACTIVE,
+            ],
+        ]);
+    }
+}

--- a/tests/Services/InAppPurchasesServiceTest.php
+++ b/tests/Services/InAppPurchasesServiceTest.php
@@ -81,7 +81,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStruct::STATUS_INACTIVE,
+                'status' => InAppPurchaseStatus::INACTIVE,
             ],
         ]);
     }

--- a/tests/Services/InAppPurchasesServiceTest.php
+++ b/tests/Services/InAppPurchasesServiceTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Context;
 use SwagExtensionStore\Services\InAppPurchasesService;
 use SwagExtensionStore\Services\StoreClient;
 use SwagExtensionStore\Struct\InAppPurchaseCollection;
+use SwagExtensionStore\Struct\InAppPurchaseStatus;
 use SwagExtensionStore\Struct\InAppPurchaseStruct;
 
 class InAppPurchasesServiceTest extends TestCase
@@ -27,12 +28,12 @@ class InAppPurchasesServiceTest extends TestCase
 
         $firstPurchase = $response->first();
         static::assertInstanceOf(InAppPurchaseStruct::class, $firstPurchase);
-        static::assertSame($firstPurchase->getStatus(), InAppPurchaseStruct::STATUS_ACTIVE);
+        static::assertSame($firstPurchase->getStatus(), InAppPurchaseStatus::ACTIVE);
         static::assertSame($firstPurchase->getIdentifier(), 'testFeature');
 
         $lastPurchase = $response->last();
         static::assertInstanceOf(InAppPurchaseStruct::class, $lastPurchase);
-        static::assertSame($lastPurchase->getStatus(), InAppPurchaseStruct::STATUS_ACTIVE);
+        static::assertSame($lastPurchase->getStatus(), InAppPurchaseStatus::ACTIVE);
         static::assertSame($lastPurchase->getIdentifier(), 'testFeature2');
     }
 
@@ -52,7 +53,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStruct::STATUS_ACTIVE,
+                'status' => InAppPurchaseStatus::ACTIVE,
             ], [
                 'extensionName' => 'testExtension',
                 'identifier' => 'testFeature2',
@@ -66,7 +67,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStruct::STATUS_ACTIVE,
+                'status' => InAppPurchaseStatus::ACTIVE,
             ], [
                 'extensionName' => 'testExtension',
                 'identifier' => 'testFeature3',


### PR DESCRIPTION
Only active IAP's are now listed in any place where IAP's are listed. 

Fixes https://github.com/shopware/SwagExtensionStore/issues/52