### PR TITLE
fix: fixed issue where all IAP's will be inactive

### DIFF
--- a/src/Struct/InAppPurchaseStruct.php
+++ b/src/Struct/InAppPurchaseStruct.php
@@ -33,6 +33,8 @@ class InAppPurchaseStruct extends Struct
      */
     public static function fromArray(array $data): self
     {
+        $data['status'] = InAppPurchaseStatus::tryFrom($data['status'] ?? 'inactive');
+
         return (new self(InAppPurchasePriceModelCollection::fromArray($data['priceModels'])))->assign($data);
     }
 

--- a/tests/Services/InAppPurchasesServiceTest.php
+++ b/tests/Services/InAppPurchasesServiceTest.php
@@ -53,7 +53,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStatus::ACTIVE,
+                'status' => 'active',
             ], [
                 'extensionName' => 'testExtension',
                 'identifier' => 'testFeature2',
@@ -67,7 +67,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStatus::ACTIVE,
+                'status' => 'active',
             ], [
                 'extensionName' => 'testExtension',
                 'identifier' => 'testFeature3',
@@ -81,7 +81,7 @@ class InAppPurchasesServiceTest extends TestCase
                     'oneTimeOnly' => false,
                     'conditionsType' => null,
                 ]],
-                'status' => InAppPurchaseStatus::INACTIVE,
+                'status' => 'inactive',
             ],
         ]);
     }


### PR DESCRIPTION
Because an enum is used, it will default to `INACTIVE` when trying to parse, unless you explicitly set it.