### PR TITLE
fix: fixed package-lock.json

### DIFF
--- a/src/Resources/app/administration/package-lock.json
+++ b/src/Resources/app/administration/package-lock.json
@@ -8,9 +8,6 @@
             "name": "swag-extension-store",
             "version": "0.0.1",
             "license": "MIT",
-            "dependencies": {
-                "slugify": "^1.6.6"
-            },
             "devDependencies": {
                 "@babel/preset-env": "^7.20.2",
                 "@shopware-ag/eslint-config-base": "2.0.0",
@@ -11528,15 +11525,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/slugify": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "node_modules/source-map": {


### PR DESCRIPTION
Removed slugify from `package-lock.json` as it's not used