### PR TITLE
[6.5.x] fix: header case sensititvity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Services/StoreDataProvider.php
+++ b/src/Services/StoreDataProvider.php
@@ -21,7 +21,7 @@ use Shopware\Core\Framework\Store\Struct\ReviewSummaryStruct;
 #[Package('services-settings')]
 class StoreDataProvider
 {
-    public const HEADER_NAME_TOTAL_COUNT = 'SW-Meta-Total';
+    public const HEADER_NAME_TOTAL_COUNT = 'sw-meta-total';
 
     private StoreClient $client;
 
@@ -69,7 +69,7 @@ class StoreDataProvider
         $listingResponse = $this->client->listExtensions($criteria, $context);
         $extensionListing = $this->extensionLoader->loadFromListingArray($context, $listingResponse['data']);
 
-        $total = $listingResponse['headers'][self::HEADER_NAME_TOTAL_COUNT][0] ?? 0;
+        $total = \array_change_key_case($listingResponse['headers'])[self::HEADER_NAME_TOTAL_COUNT][0] ?? 0;
         $extensionListing->setTotal((int) $total);
 
         return $extensionListing;


### PR DESCRIPTION
Because otherwise you'll have no pagination on the listing page