### PR TITLE
[6.4.x] fix: header case sensititvity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Services/StoreDataProvider.php
+++ b/src/Services/StoreDataProvider.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Store\Struct\ReviewSummaryStruct;
 
 class StoreDataProvider
 {
-    public const HEADER_NAME_TOTAL_COUNT = 'SW-Meta-Total';
+    public const HEADER_NAME_TOTAL_COUNT = 'sw-meta-total';
 
     private StoreClient $client;
     private ExtensionLoader $extensionLoader;
@@ -50,7 +50,7 @@ class StoreDataProvider
         $listingResponse = $this->client->listExtensions($criteria, $context);
         $extensionListing = $this->extensionLoader->loadFromListingArray($context, $listingResponse['data']);
 
-        $total = $listingResponse['headers'][self::HEADER_NAME_TOTAL_COUNT][0] ?? 0;
+        $total = \array_change_key_case($listingResponse['headers'])[self::HEADER_NAME_TOTAL_COUNT][0] ?? 0;
         $extensionListing->setTotal((int) $total);
 
         return $extensionListing;


### PR DESCRIPTION
Because otherwise you'll have no pagination on the listing page