### PR TITLE
fix: overridden my-extension modals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -36,6 +36,7 @@
 {% endblock %}
 
 {% block sw_extension_card_base_modals %}
+    {% parent %}
     <sw-extension-store-in-app-purchases-listing-modal
         v-if="showInAppPurchasesListingModal"
         :extension="extension"


### PR DESCRIPTION
### 1. Why is this change necessary?
The twig block `sw_extension_card_base_modals` of the `sw-extension-card-base` component missed a `{% parent %}` call

### 2. What does this change do, exactly?
Add the missing `{% parent %}` call

### 3. Describe each step to reproduce the issue or behaviour.
- Install Extension Store
- Try uninstalling a plugin

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123
-->
fixes shopware/shopware#9683
fixes shopware/shopware#9737