### PR TITLE
fix: pagination page reset

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-index/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-index/index.js
@@ -52,7 +52,7 @@ export default {
             handler(newValue) {
                 Shopware.Store.get('shopwareExtensions').setSearchValue({
                     key: 'page',
-                    value: 1,
+                    value: this.isTheme === this.activeFilters.group ? Shopware.Store.get('shopwareExtensions').search.page : 1,
                 });
                 this.activeFilters.group = newValue;
             },


### PR DESCRIPTION
fixes #76 

No matter which page you are on, clicking back resets the pagination to 1.