### PR TITLE
fix: align iap context link

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -29,9 +29,7 @@
         class="sw-extension-card-base__in-app-purchase__in-app-purchase-link"
         @click="openInAppPurchasesListingModal"
     >
-        <sw-internal-link hide-icon="true">
-            {{ $t('sw-extension.in-app-purchase.context-menu.in-app-purchases-label') }}
-        </sw-internal-link>
+        {{ $t('sw-extension.in-app-purchase.context-menu.in-app-purchases-label') }}
     </sw-context-menu-item>
 {% endblock %}
 

--- a/src/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
@@ -4,7 +4,7 @@
             "badge-label": "In-App Einkäufe",
             "context-menu": {
                 "account-link-label": "Einkäufe verwalten",
-                "in-app-purchases-label": "Verfügbare Käufe anzeigen"
+                "in-app-purchases-label": "Verfügbare Käufe ansehen"
             }
         }
     }

--- a/src/Resources/app/administration/src/module/sw-extension/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/sw-extension/snippet/en-GB.json
@@ -4,7 +4,7 @@
             "badge-label": "In-App Purchases",
             "context-menu": {
                 "account-link-label": "Manage purchases",
-                "in-app-purchases-label": "Show available purchases"
+                "in-app-purchases-label": "See available purchases"
             }
         }
     }


### PR DESCRIPTION
The "Show available purchases" context link looks different and uses another wording than the rest.