### PR TITLE
fix: analytics dashboard card styling

### DIFF
--- a/src/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics-promotion-card/sw-dashboard-statistics-promotion-card.html.twig
+++ b/src/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics-promotion-card/sw-dashboard-statistics-promotion-card.html.twig
@@ -1,53 +1,55 @@
-<div
+<mt-card
     v-if="showBanner"
     class="sw-dashboard-statistics-promotion-banner"
 >
-    <div class="sw-dashboard-statistics-promotion-banner__advertisement">
-        <div class="sw-dashboard-statistics-promotion-banner__advertisement-details">
-            <div
-                v-if="showBadge"
-                class="sw-dashboard-statistics-promotion-banner__advertisement-details-badge"
+    <template #grid>
+        <div class="sw-dashboard-statistics-promotion-banner__advertisement">
+            <div class="sw-dashboard-statistics-promotion-banner__advertisement-details">
+                <div
+                    v-if="showBadge"
+                    class="sw-dashboard-statistics-promotion-banner__advertisement-details-badge"
+                >
+                    {{ $t('sw-dashboard-statistics-promotion-card.badge-new') }}
+                </div>
+                <h3 class="sw-dashboard-statistics-promotion-banner__advertisement-details-title">
+                    {{ $t('sw-dashboard-statistics-promotion-card.promotion-title') }}
+                </h3>
+
+                <div class="sw-dashboard-statistics-promotion-banner__advertisement-details-description">
+                    {{ $t('sw-dashboard-statistics-promotion-card.promotion-text') }}
+                </div>
+            </div>
+            <div class="sw-dashboard-statistics-promotion-banner__advertisement-graph">
+                <img :src="assetFilter('/swagextensionstore/administration/static/img/analytics/promotion/graphic.svg')">
+            </div>
+        </div>
+
+        <div class="sw-dashboard-statistics-promotion-banner__app-card">
+            <div class="sw-dashboard-statistics-promotion-banner__app-card-app">
+                <sw-extension-icon
+                    class="sw-dashboard-statistics-promotion-banner__app-card-app-icon"
+                    :src="assetFilter('/swagextensionstore/administration/static/img/analytics/extension/icon.svg')"
+                />
+
+                <div class="sw-dashboard-statistics-promotion-banner__app-card-app-info">
+                    <h4 class="sw-dashboard-statistics-promotion-banner__app-card-app-info-name">
+                        {{ $t('sw-dashboard-statistics-promotion-card.app-name') }}
+                    </h4>
+
+                    <span class="sw-dashboard-statistics-promotion-banner__app-card-app-info-description">
+                        {{ $t('sw-dashboard-statistics-promotion-card.app-description') }}
+                    </span>
+                </div>
+            </div>
+
+            <mt-button
+                class="sw-dashboard-statistics-promotion-banner__app-card-go-to-app"
+                variant="primary"
+                :disabled="!linkToStatisticsAppExists"
+                @click="goToStatisticsAppDetailPage"
             >
-                {{ $t('sw-dashboard-statistics-promotion-card.badge-new') }}
-            </div>
-            <h3 class="sw-dashboard-statistics-promotion-banner__advertisement-details-title">
-                {{ $t('sw-dashboard-statistics-promotion-card.promotion-title') }}
-            </h3>
-
-            <div class="sw-dashboard-statistics-promotion-banner__advertisement-details-description">
-                {{ $t('sw-dashboard-statistics-promotion-card.promotion-text') }}
-            </div>
+                {{ $t('sw-dashboard-statistics-promotion-card.go-to-app') }} <mt-icon name="regular-long-arrow-right" size="12px" />
+            </mt-button>
         </div>
-        <div class="sw-dashboard-statistics-promotion-banner__advertisement-graph">
-            <img :src="assetFilter('/swagextensionstore/administration/static/img/analytics/promotion/graphic.svg')">
-        </div>
-    </div>
-
-    <div class="sw-dashboard-statistics-promotion-banner__app-card">
-        <div class="sw-dashboard-statistics-promotion-banner__app-card-app">
-            <sw-extension-icon
-                class="sw-dashboard-statistics-promotion-banner__app-card-app-icon"
-                :src="assetFilter('/swagextensionstore/administration/static/img/analytics/extension/icon.svg')"
-            />
-
-            <div class="sw-dashboard-statistics-promotion-banner__app-card-app-info">
-                <h4 class="sw-dashboard-statistics-promotion-banner__app-card-app-info-name">
-                    {{ $t('sw-dashboard-statistics-promotion-card.app-name') }}
-                </h4>
-
-                <span class="sw-dashboard-statistics-promotion-banner__app-card-app-info-description">
-                    {{ $t('sw-dashboard-statistics-promotion-card.app-description') }}
-                </span>
-            </div>
-        </div>
-
-        <mt-button
-            class="sw-dashboard-statistics-promotion-banner__app-card-go-to-app"
-            variant="primary"
-            :disabled="!linkToStatisticsAppExists"
-            @click="goToStatisticsAppDetailPage"
-        >
-            {{ $t('sw-dashboard-statistics-promotion-card.go-to-app') }} <mt-icon name="regular-long-arrow-right" size="12px" />
-        </mt-button>
-    </div>
-</div>
+    </template>
+</mt-card>

--- a/src/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics-promotion-card/sw-dashboard-statistics-promotion-card.scss
+++ b/src/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics-promotion-card/sw-dashboard-statistics-promotion-card.scss
@@ -1,12 +1,9 @@
 @import '~scss/variables';
 
 .sw-dashboard-statistics-promotion-banner {
-    display: block;
-    container-type: inline-size;
-    margin: 32px auto;
-    border-radius: $border-radius-lg;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 10%), 0 2px 1px 0 rgba(0, 0, 0, 6%), 0 1px 1px 0 rgba(0, 0, 0, 8%);
-    max-width: $content-width;
+    .mt-card {
+        overflow: visible;
+    }
 
     h3 {
         font-size: 24px;
@@ -22,8 +19,9 @@
 
     &__advertisement {
         background: linear-gradient(#003075, #0156D0);
-        border-radius: $border-radius-lg $border-radius-lg 0 0;
+        border-radius: var(--border-radius-card) var(--border-radius-card) 0 0;
         display: grid;
+        margin: -1px; // grow over mt-card border
 
         &-details {
             color: white;


### PR DESCRIPTION
The analytics promotion card on the dashboard should be a real mt-card to align with all other cards in terms of design and sizing:

![image](https://github.com/user-attachments/assets/12c2fb83-481e-4f2b-922a-bf8d26fb8881)


fixes shopware/shopware#10069