### PR TITLE
feat: accessibility banner 6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/index.js
@@ -1,0 +1,6 @@
+import template from './sw-extension-store-accessibility.html.twig';
+import './sw-extension-store-accessibility.scss';
+
+export default Shopware.Component.wrapComponentConfig({
+    template
+});

--- a/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/sw-extension-store-accessibility.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/sw-extension-store-accessibility.html.twig
@@ -1,0 +1,12 @@
+<div class="sw-extension-store-accessibility">
+    <strong class="sw-extension-store-accessibility__info">
+        {{ $tc('sw-extension-store-accessibility.accessibility-text') }}
+    </strong>
+
+    <sw-external-link
+        class="sw-extension-store-accessibility__link sw-button sw-button--primary"
+        :href="$tc('sw-extension-store-accessibility.accessibility-link')"
+    >
+        {{ $tc('sw-extension-store-accessibility.accessibility-more-information') }}&nbsp;<sw-icon name="regular-long-arrow-right" size="12px" />
+    </sw-external-link>
+</div>

--- a/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/sw-extension-store-accessibility.scss
+++ b/src/Resources/app/administration/src/module/sw-extension-store/component/sw-extension-store-accessibility/sw-extension-store-accessibility.scss
@@ -1,0 +1,21 @@
+@import '~scss/variables';
+
+.sw-extension-store-accessibility {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    background: linear-gradient(#003075, #0156D0);
+    padding: 16px 20px;
+    border-radius: $border-radius-lg;
+    margin-bottom: 20px;
+
+    &__info {
+        color: white;
+        align-self: center;
+    }
+
+    &__link {
+        justify-self: end;
+        color: white !important;
+        text-decoration: none !important;
+    }
+}

--- a/src/Resources/app/administration/src/module/sw-extension-store/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/index.js
@@ -14,6 +14,7 @@ Shopware.Component.register('sw-extension-label', () => import('./component/sw-e
 Shopware.Component.register('sw-extension-type-label', () => import('./component/sw-extension-store-type-label'));
 Shopware.Component.register('sw-extension-store-label-display', () => import('./component/sw-extension-store-label-display'));
 Shopware.Component.register('sw-extension-store-error-card', () => import('./component/sw-extension-store-error-card'));
+Shopware.Component.register('sw-extension-store-accessibility', () => import('./component/sw-extension-store-accessibility'));
 Shopware.Component.register('sw-extension-icon-polyfill', () => import('./component/sw-extension-icon-polyfill'));
 Shopware.Component.register('sw-extension-store-statistics-promotion', () => import('./component/sw-extension-store-statistics-promotion'));
 /* eslint-enable max-len */

--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-listing/sw-extension-store-listing.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-listing/sw-extension-store-listing.html.twig
@@ -4,6 +4,7 @@
             <sw-loader v-if="isLoading"></sw-loader>
         {% endblock %}
 
+        <sw-extension-store-accessibility />
         <sw-extension-store-statistics-promotion />
 
         {% block sw_extension_store_listing_filter %}

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/de-DE.json
@@ -62,5 +62,10 @@
                 "paymentMeansRequiredLinkText": "eine Zahlungsmethode hinzufügen"
             }
         }
+    },
+    "sw-extension-store-accessibility": {
+      "accessibility-text": "Erfahre mehr zu Barrierefreiheit von Erweiterungen im Shopware Store",
+      "accessibility-more-information": "Jetzt mehr erfahren",
+      "accessibility-link": "https://store.shopware.com/de/ressourcen/barrierefreiheit-von-erweiterungen/"
     }
 }

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/en-GB.json
@@ -62,5 +62,10 @@
                 "paymentMeansRequiredLinkText": "add a payment method"
             }
         }
+    },
+    "sw-extension-store-accessibility": {
+      "accessibility-text": "Learn more about accessibility of extensions in the Shopware Store",
+      "accessibility-more-information": "Learn more now",
+      "accessibility-link": "https://store.shopware.com/en/resources/accessibility-of-extensions/"
     }
 }


### PR DESCRIPTION
- fixes https://github.com/shopware/shopware/issues/10443

Adds a banner for accessibility for extensions

Backport: https://github.com/shopware/SwagExtensionStore/pull/99