### PR TITLE
fix: incorrect IAP detail result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Controller/InAppPurchasesController.php
+++ b/src/Controller/InAppPurchasesController.php
@@ -43,7 +43,7 @@ class InAppPurchasesController
     ) {
     }
 
-    #[Route('/api/_action/in-app-purchases/{technicalName}/details', name: 'api.in-app-purchases.detail', defaults: ['auth_required' => false], methods: ['GET'])]
+    #[Route('/api/_action/in-app-purchases/{technicalName}/details', name: 'api.in-app-purchases.detail', methods: ['GET'])]
     public function getInAppPurchaseDetails(string $technicalName, Context $context): Response
     {
         $criteria = new Criteria();

--- a/src/Controller/InAppPurchasesController.php
+++ b/src/Controller/InAppPurchasesController.php
@@ -43,7 +43,7 @@ class InAppPurchasesController
     ) {
     }
 
-    #[Route('/api/_action/in-app-purchases/{technicalName}/details', name: 'api.in-app-purchases.detail', methods: ['GET'])]
+    #[Route('/api/_action/in-app-purchases/{technicalName}/details', name: 'api.in-app-purchases.detail', defaults: ['auth_required' => false], methods: ['GET'])]
     public function getInAppPurchaseDetails(string $technicalName, Context $context): Response
     {
         $criteria = new Criteria();
@@ -51,7 +51,11 @@ class InAppPurchasesController
 
         $extension = $this->extensionDataProvider
             ->getInstalledExtensions($context, false, $criteria)
-            ->first();
+            ->get($technicalName);
+
+        if (!$extension) {
+            throw ExtensionStoreException::unknownExtension($technicalName);
+        }
 
         return new JsonResponse($extension);
     }

--- a/src/Exception/ExtensionStoreException.php
+++ b/src/Exception/ExtensionStoreException.php
@@ -48,4 +48,14 @@ class ExtensionStoreException extends HttpException
             'The extension provider disallowed your purchase. Please contact the extension provider.',
         );
     }
+
+    public static function unknownExtension(string $technicalName): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            'FRAMEWORK__UNKNOWN_EXTENSION',
+            'The extension with technical name "{{ technicalName }}" is not known.',
+            ['technicalName' => $technicalName],
+        );
+    }
 }

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -33,11 +33,13 @@ class InAppPurchasesControllerTest extends TestCase
     {
         $extension = new ExtensionStruct();
         $extension->setName('testExtension');
+        $otherExtension = new ExtensionStruct();
+        $otherExtension->setName('otherExtension');
         $service = $this->createMock(InAppPurchasesService::class);
         $dataProvider = $this->createMock(AbstractExtensionDataProvider::class);
         $dataProvider->expects(static::once())
             ->method('getInstalledExtensions')
-            ->willReturn(new ExtensionCollection([$extension]));
+            ->willReturn(new ExtensionCollection([$otherExtension, $extension]));
 
         $controller = new InAppPurchasesController(
             $service,

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -41,7 +41,7 @@ class InAppPurchasesControllerTest extends TestCase
             ->method('getInstalledExtensions')
             ->willReturn(new ExtensionCollection([
                 'otherExtension' => $otherExtension,
-                'testExtension' => $extension
+                'testExtension' => $extension,
             ]));
 
         $controller = new InAppPurchasesController(

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -39,7 +39,10 @@ class InAppPurchasesControllerTest extends TestCase
         $dataProvider = $this->createMock(AbstractExtensionDataProvider::class);
         $dataProvider->expects(static::once())
             ->method('getInstalledExtensions')
-            ->willReturn(new ExtensionCollection([$otherExtension, $extension]));
+            ->willReturn(new ExtensionCollection([
+                'otherExtension' => $otherExtension,
+                'testExtension' => $extension
+            ]));
 
         $controller = new InAppPurchasesController(
             $service,
@@ -54,6 +57,30 @@ class InAppPurchasesControllerTest extends TestCase
         );
 
         static::assertSame('testExtension', $content['name']);
+    }
+
+    public function testGetInAppFeatureWithUnknownExtension(): void
+    {
+        $extension = new ExtensionStruct();
+        $extension->setName('testExtension');
+        $service = $this->createMock(InAppPurchasesService::class);
+        $dataProvider = $this->createMock(AbstractExtensionDataProvider::class);
+        $dataProvider->expects(static::once())
+            ->method('getInstalledExtensions')
+            ->willReturn(new ExtensionCollection(['testExtension' => $extension]));
+
+        $controller = new InAppPurchasesController(
+            $service,
+            $this->createMock(InAppPurchaseUpdater::class),
+            $dataProvider,
+            $this->createMock(InAppPurchasesGateway::class),
+            $this->createMock(EntityRepository::class),
+        );
+
+        $this->expectException(ExtensionStoreException::class);
+        $this->expectExceptionMessage('The extension with technical name "otherExtension" is not known.');
+
+        $controller->getInAppPurchaseDetails('otherExtension', Context::createDefaultContext());
     }
 
     public function testCreateCart(): void


### PR DESCRIPTION
for weird reasons, the function from platform does not correctly filter based on the Criteria. In all other use cases, this is not important, because no Criteria is used, but in this case, first() may be a different extension.

No problem, we just do `get` as the keys are luckily already the Extension.