### PR TITLE
feat: iap upgrade and downgrade

### DIFF
--- a/src/Controller/InAppPurchasesController.php
+++ b/src/Controller/InAppPurchasesController.php
@@ -19,7 +19,6 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use SwagExtensionStore\Exception\ExtensionStoreException;
 use SwagExtensionStore\Services\InAppPurchasesService;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionCollection;
-use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -140,12 +139,9 @@ class InAppPurchasesController
     #[Route('/api/_action/in-app-purchases/{technicalName}/{inAppPurchase}', name: 'api.in-app-purchases.in-app-purchase', methods: ['GET'])]
     public function getInAppPurchase(string $technicalName, string $inAppPurchase, Context $context): Response
     {
-        $inAppPurchaseCollection = $this->inAppPurchasesService->listPurchases($technicalName, $context);
-        $iap = $inAppPurchaseCollection->filter(
-            fn (InAppPurchaseStruct $availableInAppPurchases) => $availableInAppPurchases->getIdentifier() === $inAppPurchase
-        )->first();
+        $purchase = $this->inAppPurchasesService->getInAppPurchase($technicalName, $inAppPurchase, $context);
 
-        return new JsonResponse($iap);
+        return new JsonResponse($purchase);
     }
 
     private function getAppByName(string $appName, Context $context): ?AppEntity

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-button/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-button/index.ts
@@ -1,5 +1,6 @@
 import type * as IAP from 'SwagExtensionStore/module/sw-in-app-purchases/types';
 import template from './sw-in-app-purchase-checkout-button.html.twig';
+import './sw-in-app-purchase-checkout-button.scss';
 
 /**
  * @private

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-button/sw-in-app-purchase-checkout-button.scss
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-button/sw-in-app-purchase-checkout-button.scss
@@ -1,0 +1,3 @@
+.sw-in-app-purchase-checkout-button.mt-button {
+  width: 100%;
+}

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/index.ts
@@ -27,30 +27,51 @@ export default Shopware.Component.wrapComponentConfig({
             type: String,
             required: true,
         },
+        cart: {
+            type: Object as PropType<IAP.InAppPurchaseCart>,
+            required: true,
+        },
+        variant: {
+            type: String,
+            required: true,
+        },
     },
 
     data(): {
         showConditionsModal: boolean;
-        priceModel: IAP.InAppPurchasePriceModel;
     } {
         return {
             showConditionsModal: false,
-            priceModel: this.purchase.priceModels[0],
         };
     },
 
-    created() {
-        this.setPriceModel();
+    watch: {
+        priceModel: {
+            immediate: true,
+            handler() {
+                this.onGtcAcceptedChange(this.priceModel.conditionsType === null);
+            },
+        },
     },
 
     computed: {
-        purchaseOptions(): Array<{ value: IAP.InAppPurchasePriceModel; name: string }> {
-            return this.purchase.priceModels.map((priceModel): { value: IAP.InAppPurchasePriceModel; name: string } => {
+        purchaseOptions(): Array<{ value: string; name: string }> {
+            return this.purchase.priceModels.map((priceModel): { value: string; name: string } => {
                 return {
-                    value: priceModel,
+                    value: priceModel.variant,
                     name: `€${priceModel.price}* /${this.$t(`sw-in-app-purchase-price-box.duration.${priceModel.variant}`)}`,
                 };
             });
+        },
+
+        priceModel(): IAP.InAppPurchasePriceModel {
+            return this.purchase.priceModels.find(
+                (pm: IAP.InAppPurchasePriceModel) => this.cart.positions[0].variant === pm.variant,
+            ) || this.purchase.priceModels[0];
+        },
+
+        subscriptionChange() {
+            return this.cart.positions.find(position => position.subscriptionChange !== null);
         },
     },
 
@@ -71,13 +92,10 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('update:gtc-accepted', value);
         },
 
-        setPriceModel(priceModel?: IAP.InAppPurchasePriceModel) {
-            if (!priceModel) {
-                priceModel = this.purchase.priceModels[0];
+        updateVariant(variant : string) {
+            if (this.variant !== variant) {
+                this.$emit('update:variant', variant);
             }
-            this.priceModel = priceModel;
-            this.onGtcAcceptedChange(priceModel.conditionsType === null);
-            this.$emit('update:variant', priceModel.variant);
         },
     },
 });

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/sw-in-app-purchase-checkout-overview.html.twig
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/sw-in-app-purchase-checkout-overview.html.twig
@@ -9,17 +9,24 @@
         </p>
     </div>
 
+    <sw-in-app-purchase-checkout-subscription-change
+        v-if="subscriptionChange"
+        :purchase="purchase"
+        :cart="cart"
+    />
+
     <sw-in-app-purchase-price-box
-        v-if="purchase.priceModels.length === 1"
+        v-else-if="purchase.priceModels.length === 1"
         :price-model="priceModel"
     />
 
     <sw-radio-field
         v-else
         block
+        :value="variant"
         :options="purchaseOptions"
         class="sw-in-app-purchase-checkout-purchase__feature__choices"
-        @update:value="setPriceModel"
+        @update:value="updateVariant"
     />
 
     <div class="sw-in-app-purchase-checkout-purchase__subtext">

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/sw-in-app-purchase-overview.spec.js
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-overview/sw-in-app-purchase-overview.spec.js
@@ -24,10 +24,22 @@ async function createWrapper() {
             tosAccepted: false,
             gtcAccepted: false,
             producer: 'shopware',
+            variant: 'monthly',
+            cart: {
+                netPrice: 1,
+                grossPrice: 2.99,
+                taxPrice: 2.99,
+                taxValue: 4,
+                positions: [{
+                    variant: 1,
+                    subscriptionChange: null,
+                }],
+            },
         },
         global: {
             stubs: {
                 'sw-in-app-purchase-price-box': true,
+                'sw-in-app-purchase-checkout-subscription-change': true,
                 'sw-gtc-checkbox': true,
                 'sw-radio-field': true,
                 'sw-button': true,
@@ -78,29 +90,21 @@ describe('sw-in-app-purchase-checkout-overview', () => {
         expect(wrapper.vm.showConditionsModal).toBe(false);
     });
 
-    it('should set the priceModel and emit update:variant when setPriceModel is called', async () => {
-        // when the component is created, the first price model is set emitting this data
-        // setPriceModel is called during the component creation, therefor we don't need to explicitly test it
-        expect(wrapper.vm.priceModel).toStrictEqual(wrapper.vm.purchase.priceModels[0]);
-        expect(wrapper.emitted('update:gtc-accepted')).toBeTruthy();
-        expect(wrapper.emitted('update:gtc-accepted')[0]).toEqual([true]);
-        expect(wrapper.emitted('update:variant')).toBeTruthy();
-        expect(wrapper.emitted('update:variant')[0]).toStrictEqual(['monthly']);
 
-        const priceModel = {
-            type: 'rent',
-            price: 10.99,
-            duration: 12,
-            variant: 'yearly',
-            conditionsType: null,
-        };
+    it('should render not subscription change card', async () => {
+        expect(wrapper.find('sw-in-app-purchase-checkout-subscription-change-stub').exists()).toBeFalsy();
+    });
 
-        // now we call it with a different price model, to see if it updates and emits accordingly
-        wrapper.vm.setPriceModel(priceModel);
-        expect(wrapper.vm.priceModel).toStrictEqual(priceModel);
-        expect(wrapper.emitted('update:gtc-accepted')).toBeTruthy();
-        expect(wrapper.emitted('update:gtc-accepted')[1]).toEqual([true]);
-        expect(wrapper.emitted('update:variant')).toBeTruthy();
-        expect(wrapper.emitted('update:variant')[1]).toStrictEqual(['yearly']);
+    it('should render subscription change card', async () => {
+        await wrapper.setProps({
+            cart: {
+                positions: [{
+                    variant: 1,
+                    subscriptionChange: 'upgrade',
+                }],
+            },
+        });
+
+        expect(wrapper.find('sw-in-app-purchase-checkout-subscription-change-stub')).toBeTruthy();
     });
 });

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/index.ts
@@ -1,0 +1,69 @@
+import type * as IAP from "SwagExtensionStore/module/sw-in-app-purchases/types";
+import template from "./sw-in-app-purchase-checkout-subscription-change.html.twig";
+import './sw-in-app-purchase-checkout-subscription-change.scss';
+
+export default Shopware.Component.wrapComponentConfig({
+    template,
+
+    props: {
+        purchase: {
+            type: Object as PropType<IAP.InAppPurchase>,
+            required: true,
+        },
+        cart: {
+            type: Object as PropType<IAP.InAppPurchaseCart>,
+            required: true,
+        },
+    },
+
+    computed: {
+        locale() {
+            const local = String(Shopware.Store.get('session').currentLocale ??
+                Shopware.Store.get('context').app?.fallbackLocale ?? 'en-GB');
+
+            return new Intl.Locale(local);
+        },
+
+        currencyFilter() {
+            return Shopware.Filter.getByName('currency');
+        },
+
+        formattedStartingDate(): string {
+            const date = new Date(this.cartPosition.nextBookingDate ?? '');
+            return date.toLocaleDateString(this.locale, { month: "numeric", day: "numeric" });
+        },
+
+        infoHint(): string {
+            const today = new Date().toLocaleDateString(this.locale, {
+                month: 'long',
+                day: 'numeric',
+            });
+
+            const nextBookingDate = this.cartPosition?.nextBookingDate
+                ? new Date(this.cartPosition.nextBookingDate).toLocaleDateString(this.locale, {
+                    month: 'long',
+                    day: 'numeric',
+                })
+                : '';
+
+            return this.$t('sw-in-app-purchase-checkout-subscription-change.info-lint', {
+                today,
+                price: this.currencyFilter(this.cartPosition?.proratedNetPrice, 'EUR', 2),
+                variant: this.cartPosition?.variant ?? '',
+                fee: this.currencyFilter(this.cart.netPrice, 'EUR', 2),
+                start: nextBookingDate,
+            });
+        },
+
+        cartPosition() {
+            return this.cart.positions[0];
+        },
+
+        getCurrentPrice() {
+            const price = this.cartPosition?.subscriptionChange?.currentFeature?.priceModels
+                ?.find((priceModel) => priceModel.variant === this.cartPosition.variant)?.price;
+
+            return String(this.currencyFilter(price, 'EUR', 2));
+        },
+    },
+});

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/sw-in-app-purchase-checkout-subscription-change.html.twig
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/sw-in-app-purchase-checkout-subscription-change.html.twig
@@ -1,0 +1,36 @@
+<div class="sw-in-app-purchase-checkout-subscription-change">
+    <div class="sw-in-app-purchase-checkout-subscription-change__item">
+        <p class="sw-in-app-purchase-checkout-subscription-change__plan-name">
+            {{ $t('sw-in-app-purchase-checkout-subscription-change.current-plan') }}
+        </p>
+        <p class="sw-in-app-purchase-checkout-subscription-change__plan-price">
+            {{ getCurrentPrice }}*/{{ $t('sw-in-app-purchase-price-box.duration.' + cartPosition.variant) }}
+        </p>
+    </div>
+    <div class="sw-in-app-purchase-checkout-subscription-change__item">
+        <p class="sw-in-app-purchase-checkout-subscription-change__plan-name">
+            {{ $t('sw-in-app-purchase-checkout-subscription-change.new-plan') }}
+            <span class="sw-in-app-purchase-checkout-subscription-change__note">
+                ({{ $t('sw-in-app-purchase-checkout-subscription-change.starting') }} {{ formattedStartingDate }})
+            </span>
+        </p>
+        <p class="sw-in-app-purchase-checkout-subscription-change__plan-price">
+            {{ currencyFilter(cart.netPrice, 'EUR', 2) }}*/{{ $t('sw-in-app-purchase-price-box.duration.' + cartPosition.variant) }}
+        </p>
+    </div>
+
+    <div class="sw-in-app-purchase-checkout-subscription-change__divider" />
+
+    <div class="sw-in-app-purchase-checkout-subscription-change__item">
+        <p class="sw-in-app-purchase-checkout-subscription-change__due-day">
+            {{ $t('sw-in-app-purchase-checkout-subscription-change.due-today') }}
+        </p>
+        <p class="sw-in-app-purchase-checkout-subscription-change__due-day">
+            {{ currencyFilter(cartPosition.proratedNetPrice, 'EUR', 2) }}*
+        </p>
+    </div>
+
+    <p class="sw-in-app-purchase-checkout-subscription-change__info-hint">
+{{ infoHint }}
+</p>
+</div>

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/sw-in-app-purchase-checkout-subscription-change.scss
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout-subscription-change/sw-in-app-purchase-checkout-subscription-change.scss
@@ -1,0 +1,36 @@
+.sw-in-app-purchase-checkout-subscription-change {
+  padding: var(--scale-size-16);
+  background-color: var(--color-background-brand-default);
+  border: 1px solid var(--color-shopware-brand-900);
+  border-radius: var(--border-radius-default);
+  display: flex;
+  flex-direction: column;
+  gap: var(--scale-size-24);
+  font-size: var(--font-size-xs);
+  line-height: var(--font-line-height-xs);
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--scale-size-16);
+  }
+
+  &__plan-price, &__due-day {
+    font-size: var(--font-size-m);
+    line-height: var(--font-line-height-m);
+  }
+
+  &__due-day {
+    margin-top: var(--scale-size-16);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  &__note, &__info-hin {
+    color: var(--color-text-secondary-default);
+  }
+
+  &__divider {
+    border-bottom: 1px solid var(--color-shopware-brand-900);
+  }
+}

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/index.ts
@@ -58,10 +58,32 @@ export default Shopware.Component.wrapComponentConfig({
             });
         },
 
+        createCart(variant: string) {
+            if (!this.store.extension || !this.store.entry || !variant) {
+                this.reset();
+                return;
+            }
+
+            this.variant = variant;
+            this.state = 'loading';
+
+            this.inAppPurchasesService.createCart(
+                this.store.extension,
+                this.store.entry.identifier,
+                variant,
+            ).then((cart) => {
+                this.inAppPurchaseCart = cart;
+                this.state = 'purchase';
+            }).catch ((errorResponse: ErrorResponse) => {
+                Shopware.Utils.debug.error("checkout-iap", errorResponse);
+                this.errorMessage = this.getError(errorResponse);
+                this.state = 'error';
+            });
+        },
+
         async requestFeature() {
             if (!this.store.extension || !this.store.entry) {
                 this.reset();
-
                 return;
             }
 
@@ -71,37 +93,35 @@ export default Shopware.Component.wrapComponentConfig({
                 this.inAppPurchasesService.getExtension(this.store.extension),
                 this.inAppPurchasesService.getPriceModels(this.store.extension, this.store.entry.identifier),
             ]).then(([extension, purchase]) => {
-                this.purchase = purchase;
                 this.extension = extension;
-                this.state = 'purchase';
-            }).catch((errorResponse: ErrorResponse) => {
-                Shopware.Utils.debug.error(errorResponse);
+                this.purchase = purchase;
+
+                if (!this.purchase) {
+                    throw new Error('No in-app purchase foud');
+                }
+
+                return this.createCart(this.purchase.preselectedVariant);
+            }).catch ((errorResponse: ErrorResponse)=> {
+                Shopware.Utils.debug.error("checkout-iap", errorResponse);
                 this.errorMessage = this.getError(errorResponse);
                 this.state = 'error';
             });
         },
 
         onPurchaseFeature() {
-            if (!this.store.extension || !this.store.entry || !this.variant) {
+            if (!this.inAppPurchaseCart || !this.extension) {
                 this.reset();
-
                 return;
             }
 
-            this.inAppPurchasesService.createCart(
-                this.store.extension,
-                this.store.entry.identifier,
-                this.variant,
-            ).then((inAppPurchaseCart) => {
-                return this.inAppPurchasesService.orderCart(
-                    inAppPurchaseCart?.taxRate,
-                    inAppPurchaseCart?.positions,
-                    this.extension?.name,
-                );
-            }).then(() => {
+            this.inAppPurchasesService.orderCart(
+                this.inAppPurchaseCart.taxRate,
+                this.inAppPurchaseCart.positions,
+                this.extension.name,
+            ).then(() => {
                 this.state = 'success';
             }).catch((errorResponse: ErrorResponse) => {
-                Shopware.Utils.debug.error(errorResponse);
+                Shopware.Utils.debug.error("checkout-iap", errorResponse);
                 this.errorMessage = this.getError(errorResponse);
                 this.state = 'error';
             });

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/sw-in-app-purchase-checkout.html.twig
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/sw-in-app-purchase-checkout.html.twig
@@ -29,6 +29,8 @@
         v-model:variant="variant"
         :purchase="purchase"
         :producer="extension.producerName"
+        :cart="inAppPurchaseCart"
+        @update:variant="createCart"
     />
 
     <sw-in-app-purchase-checkout-state

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/sw-in-app-purchase-checkout.spec.js
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout/sw-in-app-purchase-checkout.spec.js
@@ -46,13 +46,14 @@ async function createWrapper() {
                         return Promise.resolve();
                     },
                     getPriceModels: () => {
-                        return Promise.resolve([{
+                        return Promise.resolve({
                             type: 'rent',
                             price: 0.99,
                             duration: 1,
                             variant: 'monthly',
                             conditionsType: null,
-                        }]);
+                            preselectedVariant: 'monthly',
+                        });
                     },
                 },
             },
@@ -205,6 +206,8 @@ describe('src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout',
     });
 
     it('catches error if createCart fails', async () => {
+        Shopware.Utils.debug.error = jest.fn();
+
         wrapper.vm.inAppPurchasesService.createCart = () => {
             return Promise.reject(new Error('Test error'));
         };
@@ -223,7 +226,7 @@ describe('src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout',
         wrapper.vm.variant = 'service';
         wrapper.vm.store.request({ featureId: 'your-feature-id' }, 'jestapp');
 
-        wrapper.vm.onPurchaseFeature();
+        wrapper.vm.createCart('monthly');
         expect(wrapper.vm.state).toBe('loading');
 
         await flushPromises();
@@ -250,8 +253,8 @@ describe('src/module/sw-in-app-purchases/component/sw-in-app-purchase-checkout',
                 active: true,
             },
         };
-        wrapper.vm.variant = 'service';
-        wrapper.vm.store.request({ featureId: 'your-feature-id' }, 'jestapp');
+        wrapper.vm.inAppPurchaseCart = "Dummy card";
+        wrapper.vm.extension = 'Dummy extension';
 
         wrapper.vm.onPurchaseFeature();
         expect(wrapper.vm.state).toBe('loading');

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/index.ts
@@ -23,5 +23,9 @@ export default Shopware.Component.wrapComponentConfig({
 
             return null;
         },
+
+        currencyFilter() {
+            return Shopware.Filter.getByName('currency');
+        },
     },
 });

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/sw-in-app-purchase-price-box.html.twig
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/sw-in-app-purchase-price-box.html.twig
@@ -1,7 +1,7 @@
 <mt-banner class="sw-in-app-purchase-price-box" :hide-icon="true">
     <span class="sw-in-app-purchase-price-box__price_container">
         <span class="sw-in-app-purchase-price-box__price">
-            € {{ String(priceModel?.price) }}*
+            {{ currencyFilter(String(priceModel?.price), "EUR", 2) }}*
         </span>
 
         <span v-if="rentDuration" class="sw-in-app-purchase-price-box__duration">

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/sw-in-app-purchase-price-box.scss
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/component/sw-in-app-purchase-price-box/sw-in-app-purchase-price-box.scss
@@ -1,3 +1,8 @@
+.sw-in-app-purchase-price-box.mt-banner--neutral {
+    background-color: var(--color-background-brand-default);
+    border: 1px solid var(--color-shopware-brand-900);
+}
+
 .sw-in-app-purchase-price-box {
     width: 100%;
     margin: 0;

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/index.ts
@@ -17,6 +17,10 @@ Shopware.Component.register(
     () => import('./component/sw-in-app-purchase-checkout-state'),
 );
 Shopware.Component.register(
+    'sw-in-app-purchase-checkout-subscription-change',
+    () => import('./component/sw-in-app-purchase-checkout-subscription-change'),
+);
+Shopware.Component.register(
     'sw-in-app-purchase-price-box',
     () => import('./component/sw-in-app-purchase-price-box'),
 );

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/service/in-app-purchases.service.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/service/in-app-purchases.service.ts
@@ -25,7 +25,7 @@ export default class InAppPurchasesService extends ApiService {
         ).then(ApiService.handleResponse.bind(this));
     }
 
-    async orderCart(taxRate: number, positions: IAP.InAppPurchaseCartPositions, name: string) {
+    async orderCart(taxRate: number, positions: IAP.InAppPurchaseCartPosition[], name: string) {
         return this.httpClient.post<IAP.InAppPurchase>(
             `_action/${this.apiEndpoint}/cart/order`,
             { taxRate, positions, name },

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/snippet/de-DE.json
@@ -31,5 +31,12 @@
       "monthly": "monatlich",
       "yearly": "jährlich"
     }
+  },
+  "sw-in-app-purchase-checkout-subscription-change": {
+    "current-plan": "Aktueller Plan",
+    "new-plan": "Neuer Plan",
+    "starting": "Beginn",
+    "due-today": "Heute fällig",
+    "info-lint": "Basierend auf dem heutigen Datum {today} beträgt Ihre anteilige Upgrade-Gebühr {price}. Ihre reguläre {variant} Gebühr von {fee} beginnt am {start}."
   }
 }

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/snippet/en-GB.json
@@ -31,5 +31,12 @@
       "monthly": "monthly",
       "yearly": "yearly"
     }
+  },
+  "sw-in-app-purchase-checkout-subscription-change": {
+    "current-plan": "Current plan",
+    "new-plan": "New plan",
+    "starting": "Starting",
+    "due-today": "Due today",
+    "info-lint": "Based on today’s date {today}, your prorated upgrade charge is {price}. Your regular {variant} charge of {fee} will start on {start}."
   }
 }

--- a/src/Resources/app/administration/src/module/sw-in-app-purchases/types/index.ts
+++ b/src/Resources/app/administration/src/module/sw-in-app-purchases/types/index.ts
@@ -17,15 +17,30 @@ export type InAppPurchase = {
     serviceConditions?: string | null;
     websiteGtc?: string | null;
     priceModels: Array<InAppPurchasePriceModel>;
+    priceModel: InAppPurchasePriceModel;
+    preselectedVariant: string;
 };
 
-export type InAppPurchaseCartPositions = {
+export type InAppSubscriptionChange = {
+    id: string;
+    type: 'upgrade' | 'downgrade';
+    currentNetPrice: number;
+    currentFeatureVariant: string;
+    currentFeature: InAppPurchase;
+    pendingDowngrade: string;
+};
+
+export type InAppPurchaseCartPosition = {
     feature: InAppPurchase;
     priceModel: InAppPurchasePriceModel;
     netPrice: number;
     grossPrice: number;
     taxRate: number;
     taxValue: number;
+    nextBookingDate: null | Date;
+    subscriptionChange: null | InAppSubscriptionChange;
+    proratedNetPrice: null | number;
+    variant: 'non-consumable' | 'service' | 'monthly' | 'yearly';
 };
 
 export type InAppPurchaseCart = {
@@ -33,7 +48,7 @@ export type InAppPurchaseCart = {
     grossPrice: number;
     taxRate: number;
     taxValue: number;
-    positions: Array<InAppPurchaseCartPositions>;
+    positions: Array<InAppPurchaseCartPosition>;
 };
 
 export type InAppPurchaseCollection = Array<InAppPurchase>;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,10 +13,10 @@
             <parameter key="create_basket">/swplatform/extensionstore/baskets</parameter>
             <parameter key="order_basket">/swplatform/extensionstore/orders</parameter>
             <parameter key="payment_means">/swplatform/extensionstore/paymentmeans</parameter>
-            <parameter key="iap_details">/swplatform/store/extensions/%%d/inappfeatures/%%s</parameter>
             <parameter key="iap_create_basket">/swplatform/inappfeatures/baskets</parameter>
             <parameter key="iap_order_basket">/swplatform/inappfeatures/orders</parameter>
             <parameter key="iap_list">/swplatform/extensionstore/extensions/%s/inappfeatures</parameter>
+            <parameter key="iap_details">/swplatform/extensionstore/extensions/%%s/inappfeatures/%%s</parameter>
         </parameter>
     </parameters>
     <services>

--- a/src/Services/InAppPurchasesService.php
+++ b/src/Services/InAppPurchasesService.php
@@ -14,7 +14,7 @@ use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
- * @phpstan-import-type InAppPurchaseCartPosition from InAppPurchaseCartPositionStruct
+ * @phpstan-import-type InAppPurchaseCartItem from InAppPurchaseCartPositionStruct
  */
 #[Package('checkout')]
 class InAppPurchasesService
@@ -30,7 +30,7 @@ class InAppPurchasesService
     }
 
     /**
-     * @param array<int, InAppPurchaseCartPosition> $positions
+     * @param array<int, InAppPurchaseCartItem> $positions
      */
     public function orderCart(float $taxRate, array $positions, Context $context): JsonResponse
     {
@@ -42,5 +42,10 @@ class InAppPurchasesService
         $purchases = $this->client->listInAppPurchases($extensionName, $context);
 
         return $purchases->filter(fn (InAppPurchaseStruct $purchase) => $purchase->getStatus() === InAppPurchaseStatus::ACTIVE);
+    }
+
+    public function getInAppPurchase(string $extensionName, string $inAppPurchase, Context $context): InAppPurchaseStruct
+    {
+        return $this->client->getInAppPurchase($extensionName, $inAppPurchase, $context);
     }
 }

--- a/src/Services/StoreClient.php
+++ b/src/Services/StoreClient.php
@@ -15,6 +15,7 @@ use SwagExtensionStore\Exception\ExtensionStoreException;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCollection;
+use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -30,7 +31,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * @phpstan-type ExtensionReview array<string, mixed>
  * @phpstan-type PaymentMethod array{id: positive-int, type: 'paypal'|'creditCard'|'directDebit', label: string, default: bool}
  *
- * @phpstan-import-type InAppPurchaseCartPosition from InAppPurchaseCartPositionStruct
+ * @phpstan-import-type InAppPurchaseCartItem from InAppPurchaseCartPositionStruct
  */
 #[Package('checkout')]
 class StoreClient
@@ -233,7 +234,7 @@ class StoreClient
     }
 
     /**
-     * @param array<int, InAppPurchaseCartPosition> $positions
+     * @param array<int, InAppPurchaseCartItem> $positions
      */
     public function orderInAppPurchaseCart(float $taxRate, array $positions, Context $context): JsonResponse
     {
@@ -273,5 +274,23 @@ class StoreClient
         }
 
         return InAppPurchaseCollection::fromArray(json_decode((string) $response->getBody(), true));
+    }
+
+    public function getInAppPurchase(string $extensionName, string $inAppPurchase, Context $context): InAppPurchaseStruct
+    {
+        try {
+            $response = $this->client->request(
+                'GET',
+                \sprintf($this->endpoints['iap_details'], $extensionName, $inAppPurchase),
+                [
+                    'query' => $this->storeRequestOptionsProvider->getDefaultQueryParameters($context),
+                    'headers' => $this->storeRequestOptionsProvider->getAuthenticationHeader($context),
+                ],
+            );
+        } catch (ClientException $e) {
+            throw ExtensionStoreException::createStoreApiExceptionFromClientError($e);
+        }
+
+        return InAppPurchaseStruct::fromArray(json_decode((string) $response->getBody(), true));
     }
 }

--- a/src/Struct/InAppPurchaseCartPositionCollection.php
+++ b/src/Struct/InAppPurchaseCartPositionCollection.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Struct\Collection;
  * @template-extends Collection<InAppPurchaseCartPositionStruct>
  *
  * @phpstan-import-type InAppPurchaseCartPosition from InAppPurchaseCartPositionStruct
+ * @phpstan-import-type InAppPurchaseCartItem from InAppPurchaseCartPositionStruct
  */
 #[Package('checkout')]
 class InAppPurchaseCartPositionCollection extends Collection
@@ -28,7 +29,7 @@ class InAppPurchaseCartPositionCollection extends Collection
     }
 
     /**
-     * @return array<int, InAppPurchaseCartPosition>
+     * @return array<int, InAppPurchaseCartItem>
      */
     public function toCart(): array
     {

--- a/src/Struct/InAppPurchaseCartPositionStruct.php
+++ b/src/Struct/InAppPurchaseCartPositionStruct.php
@@ -12,19 +12,24 @@ use Shopware\Core\Framework\Struct\Struct;
  *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePriceModel from InAppPurchasePriceModelStruct
+ * @phpstan-import-type InAppPurchaseSubscriptionChange from InAppPurchaseSubscriptionChangeStruct
  *
- * @phpstan-type InAppPurchaseCartPosition array{extensionName: string, inAppFeatureIdentifier: string, netPrice: float, grossPrice: float, taxRate: float, taxValue: float}
+ * @phpstan-type InAppPurchaseCartPosition array{subscriptionChange?: InAppPurchaseSubscriptionChange, extensionName: string, inAppFeatureIdentifier: string, netPrice: float, grossPrice: float, taxRate: float, taxValue: float}
+ * @phpstan-type InAppPurchaseCartItem array{extensionName: string, inAppFeatureIdentifier: string, netPrice: float, taxValue: float, grossPrice: float, taxRate: float, variant: string, subscriptionChange?: array{type: string, currentInAppFeatureIdentifier: string}}
  */
 #[Package('checkout')]
 class InAppPurchaseCartPositionStruct extends Struct
 {
     private function __construct(
+        protected ?InAppPurchaseSubscriptionChangeStruct $subscriptionChange,
         protected string $extensionName = '',
         protected string $inAppFeatureIdentifier = '',
         protected float $netPrice = 0.0,
         protected float $grossPrice = 0.0,
         protected float $taxRate = 0.0,
         protected float $taxValue = 0.0,
+        protected float $proratedNetPrice = 0.0,
+        protected string $variant = '',
     ) {
     }
 
@@ -33,7 +38,13 @@ class InAppPurchaseCartPositionStruct extends Struct
      */
     public static function fromArray(array $data): self
     {
-        $inAppPurchaseCartPosition = (new self())->assign($data);
+        $subscriptionChange = null;
+
+        if (!empty($data['subscriptionChange'])) {
+            $subscriptionChange = InAppPurchaseSubscriptionChangeStruct::fromArray($data['subscriptionChange']);
+        }
+
+        $inAppPurchaseCartPosition = (new self($subscriptionChange))->assign($data);
         if ($inAppPurchaseCartPosition->getInAppFeatureIdentifier() === '') {
             $inAppPurchaseCartPosition->setInAppFeatureIdentifier($data['feature']['identifier'] ?? '');
         }
@@ -42,18 +53,25 @@ class InAppPurchaseCartPositionStruct extends Struct
     }
 
     /**
-     * @return InAppPurchaseCartPosition
+     * @return InAppPurchaseCartItem
      */
     public function toCart(): array
     {
-        return [
+        $data = [
             'extensionName' => $this->getExtensionName(),
             'inAppFeatureIdentifier' => $this->getInAppFeatureIdentifier(),
             'netPrice' => $this->getNetPrice(),
             'taxValue' => $this->getTaxValue(),
             'grossPrice' => $this->getGrossPrice(),
             'taxRate' => $this->getTaxRate(),
+            'variant' => $this->getVariant(),
         ];
+
+        if ($this->subscriptionChange) {
+            $data['subscriptionChange'] = $this->subscriptionChange->toCart();
+        }
+
+        return $data;
     }
 
     public function getInAppFeatureIdentifier(): string
@@ -114,5 +132,25 @@ class InAppPurchaseCartPositionStruct extends Struct
     public function setExtensionName(string $name): void
     {
         $this->extensionName = $name;
+    }
+
+    public function getProratedNetPrice(): float
+    {
+        return $this->proratedNetPrice;
+    }
+
+    public function setProratedNetPrice(float $proratedNetPrice): void
+    {
+        $this->proratedNetPrice = $proratedNetPrice;
+    }
+
+    public function getVariant(): string
+    {
+        return $this->variant;
+    }
+
+    public function setVariant(string $variant): void
+    {
+        $this->variant = $variant;
     }
 }

--- a/src/Struct/InAppPurchaseStruct.php
+++ b/src/Struct/InAppPurchaseStruct.php
@@ -25,6 +25,7 @@ class InAppPurchaseStruct extends Struct
         protected ?string $description = null,
         protected ?string $serviceConditions = null,
         protected ?string $websiteGtc = null,
+        protected ?string $preselectedVariant = null,
     ) {
     }
 
@@ -111,5 +112,15 @@ class InAppPurchaseStruct extends Struct
     public function setStatus(InAppPurchaseStatus $status): void
     {
         $this->status = $status;
+    }
+
+    public function getPreselectedVariant(): ?string
+    {
+        return $this->preselectedVariant;
+    }
+
+    public function setPreselectedVariant(?string $preselectedVariant): void
+    {
+        $this->preselectedVariant = $preselectedVariant;
     }
 }

--- a/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
+++ b/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace SwagExtensionStore\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
+ *
+ * @phpstan-type InAppPurchaseSubscriptionChange array{currentFeature: InAppPurchase, type: string, currentFeatureVariant: string, currentNetPrice: string, pendingDowngrade: string}
+ */
+#[Package('checkout')]
+class InAppPurchaseSubscriptionChangeStruct extends Struct
+{
+    private function __construct(
+        protected InAppPurchaseStruct $currentFeature,
+        protected string $type = '',
+        protected string $currentFeatureVariant = '',
+        protected string $currentNetPrice = '',
+        protected string $pendingDowngrade = '',
+    ) {
+    }
+
+    /**
+     * @param InAppPurchaseSubscriptionChange $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return (new self(InAppPurchaseStruct::fromArray($data['currentFeature'])))->assign($data);
+    }
+
+    /**
+     * @return array{type: string, currentInAppFeatureIdentifier: string}
+     */
+    public function toCart(): array
+    {
+        return [
+            'type' => $this->getType(),
+            'currentInAppFeatureIdentifier' => $this->getCurrentFeature()->getIdentifier(),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getCurrentFeature(): InAppPurchaseStruct
+    {
+        return $this->currentFeature;
+    }
+
+    public function setCurrentFeature(InAppPurchaseStruct $currentFeature): void
+    {
+        $this->currentFeature = $currentFeature;
+    }
+
+    public function getCurrentFeatureVariant(): string
+    {
+        return $this->currentFeatureVariant;
+    }
+
+    public function setCurrentFeatureVariant(string $currentFeatureVariant): void
+    {
+        $this->currentFeatureVariant = $currentFeatureVariant;
+    }
+
+    public function getCurrentNetPrice(): string
+    {
+        return $this->currentNetPrice;
+    }
+
+    public function setCurrentNetPrice(string $currentNetPrice): void
+    {
+        $this->currentNetPrice = $currentNetPrice;
+    }
+
+    public function getPendingDowngrade(): string
+    {
+        return $this->pendingDowngrade;
+    }
+
+    public function setPendingDowngrade(string $pendingDowngrade): void
+    {
+        $this->pendingDowngrade = $pendingDowngrade;
+    }
+}

--- a/tests/Services/StoreClientTest.php
+++ b/tests/Services/StoreClientTest.php
@@ -16,7 +16,7 @@ use SwagExtensionStore\Services\StoreClient;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 
 /**
- * @phpstan-import-type InAppPurchaseCartPosition from InAppPurchaseCartPositionStruct
+ * @phpstan-import-type InAppPurchaseCartItem from InAppPurchaseCartPositionStruct
  */
 class StoreClientTest extends TestCase
 {
@@ -163,7 +163,7 @@ class StoreClientTest extends TestCase
     }
 
     /**
-     * @return array<int, InAppPurchaseCartPosition> $positions
+     * @return array<int, InAppPurchaseCartItem>
      */
     private function buildPositions(): array
     {
@@ -175,6 +175,7 @@ class StoreClientTest extends TestCase
                 'taxValue' => 1.90,
                 'grossPrice' => 11.89,
                 'taxRate' => 19.0,
+                'variant' => 'monthly',
             ],
         ];
     }


### PR DESCRIPTION
### In-App Purchase: Upgrade and Downgrade

If a merchant has already purchased an in-app feature, they can now upgrade to a higher plan (e.g., from **Basic** to **Pro**) or downgrade to a lower plan (e.g., from **Pro** to **Basic**).

As part of the implementation, a new admin component was introduced based on the updated design. Additionally, the purchase process was redefined, since we now require a **cart** to check whether the merchant already owns the feature. This information is retrieved via a new **SBP endpoint**.

The SBP endpoint returns information about the merchant's current in-app purchases. Based on that data, we can determine if the requested feature is already owned and whether an upgrade or downgrade is applicable.

Furthermore, the `api.in-app-purchases.cart.order` call has now optional supports for an additional body parameter:

#### For upgrades:

```json
"subscriptionChange": {
  "type": "upgrade",
  "currentInAppFeatureIdentifier": "identifier"
}
```

#### For downgrades:

```json
"subscriptionChange": {
  "type": "downgrade",
  "currentInAppFeatureIdentifier": "identifier"
}
```

If the `subscriptionChange` parameter is not set, the system will treat the request as a **new purchase**.