### PR TITLE
fix: open extension buy modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "swag/swag-extension-store",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "SWAG Extension Store",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store.service.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store.service.ts
@@ -17,7 +17,7 @@ export default class ExtensionStoreService {
     }
 
     public orderVariantsByPricePerMonth(variants: ExtensionVariant[]): ExtensionVariant[] {
-        return variants.sort((first, second) => {
+        return variants.toSorted((first, second) => {
             const firstPrice = this.getPriceFromVariant(first, true);
             const secondPrice = this.getPriceFromVariant(second, true);
 
@@ -30,7 +30,7 @@ export default class ExtensionStoreService {
             return variants;
         }
 
-        return variants.sort((first, second) => {
+        return variants.toSorted((first, second) => {
             if (!first.duration || !second.duration) {
                 return 0;
             }

--- a/src/Resources/app/administration/tsconfig.json
+++ b/src/Resources/app/administration/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "ES2023"],
     "module": "commonjs",
     "skipLibCheck": true,
     "allowJs": true,


### PR DESCRIPTION
`orderVariantsByPricePerMonth` and `orderVariantsByRentDuration` are used in computed values. `Array.sort` will sort the array in place, mutating the value used in computed values, resulting in infinite recursion.

fixes shopware/shopware#12955