### PR TITLE
chore: suppress phpstan deprecated set() warning in tests

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -21,22 +21,18 @@ jobs:
           shopwareVersion: trunk
           install-admin: true
 
-      - name: Jest Unit Tests
-        shell: bash
-        working-directory: custom/plugins/SwagExtensionStore/src/Resources/app/administration
-        run: npm run unit -- --coverage
-
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+      - uses: shopware/github-actions/admin-jest@main
+        with:
+          extensionName: SwagExtensionStore
+          uploadCoverage: 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          root_dir: ${{ github.workspace }}/custom/plugins/SwagExtensionStore
-          working-directory: ${{ github.workspace }}/custom/plugins/SwagExtensionStore
-          directory: ${{ github.workspace }}/custom/plugins/SwagExtensionStore/src/Resources/app/administration
+
   lint:
     name: ESLint
-    uses: shopware/github-actions/.github/workflows/admin-eslint.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-      shopwareVersion: trunk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/eslint@main
+        with:
+          extensionName: SwagExtensionStore
+          shopwareVersion: trunk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - trunk
 jobs:
   build:
-    uses: shopware/github-actions/.github/workflows/build-zip.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
+    name: Build and Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/build-zip@main
+        with:
+          extensionName: ${{ github.event.repository.name }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '**/*.php'
+      - 'phpstan.neon.dist'
       - .github/workflows/php.yml
   push:
     paths:
@@ -14,22 +15,42 @@ on:
     - cron: '0 3 * * *'
 jobs:
   cs:
-    uses: shopware/github-actions/.github/workflows/cs-fixer.yml@main
-    with:
-      rules: ''
+    name: Check Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/cs-fixer@main
+        with:
+          rules: ''
 
   phpstan:
-    uses: shopware/github-actions/.github/workflows/phpstan.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-      shopwareVersion: trunk
+    name: Static Analyse
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup extension
+        uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: SwagExtensionStore
+          shopwareVersion: trunk
+          install: true
+
+      - uses: shopware/github-actions/phpstan@main
+        with:
+          extensionName: SwagExtensionStore
 
   phpunit:
-    uses: shopware/github-actions/.github/workflows/phpunit.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-      shopwareVersion: trunk
-      uploadCoverage: true
-      filterName: swagextensionstore-testsuite
-    secrets:
-      codecovToken: ${{ secrets.CODECOV_TOKEN }}
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup extension
+        uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: SwagExtensionStore
+          shopwareVersion: trunk
+
+      - uses: shopware/github-actions/phpunit@main
+        with:
+          extensionName: SwagExtensionStore
+          uploadCoverage: 'true'
+          filterName: swagextensionstore-testsuite
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -3,10 +3,12 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    uses: shopware/github-actions/.github/workflows/store-release.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-    secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
-      ghToken: ${{ secrets.GITHUB_TOKEN }}
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/store-release@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+          accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
+          accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,6 +19,10 @@ parameters:
             message: '#Service ".*" is private#'
             path: tests
 
+        -
+            message: '#Call to deprecated method set\(\) of class Shopware\\Core\\System\\SystemConfig\\SystemConfigService#'
+            path: tests
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/src/Resources/app/administration/jest.config.js
+++ b/src/Resources/app/administration/jest.config.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     transformIgnorePatterns: [
-        '/node_modules/(?!(@shopware-ag/meteor-component-library|@shopware-ag/meteor-icon-kit|uuidv7)/)'
+        '/node_modules/(?!(@shopware-ag/meteor-component-library|@shopware-ag/meteor-icon-kit|uuidv7|lodash-es)/)'
     ],
 
     moduleNameMapper: {


### PR DESCRIPTION
## Summary

- Ignore phpstan deprecation warning for `SystemConfigService::set()` in test files, consistent with the existing private service ignore rule