### PR TITLE
Update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: shopware/github-actions/store-release@main
         with:
           extensionName: ${{ github.event.repository.name }}
-          accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-          accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+          clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+          clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
           ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Migrate the store release workflow from account user/password authentication to client ID/secret credentials
- Replace `accountUser` / `accountPassword` with `clientId` / `clientSecret`
- Update secret references from `SHOPWARE_ACCOUNT_USER` / `SHOPWARE_ACCOUNT_PASSWORD` to `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` / `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET`

This aligns the workflow with the updated `shopware/github-actions/store-release` action, which now uses OAuth client credentials instead of account user/password for authentication.