### PR TITLE
fix: run store release as composite action (6.6.x)

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -3,10 +3,12 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    uses: shopware/github-actions/.github/workflows/store-release.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-    secrets:
-      clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
-      clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
-      ghToken: ${{ secrets.GITHUB_TOKEN }}
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/store-release@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+          clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+          clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switches the store release workflow from the reusable workflow call to the composite `shopware/github-actions/store-release@main` action.
- Keeps `clientId` and `clientSecret` sourced from the existing GitHub secrets.

## Root Cause
The reusable workflow call only accepts its declared `workflow_call` secrets. Passing `clientId` and `clientSecret` there makes GitHub fail the run during workflow startup before any job is created.

## Impact
The `6.6.x` store release workflow now matches the working `trunk` pattern and passes the client credentials to the action inputs while still reading the values from GitHub secrets.
