### PR TITLE
fix: replace ShopwarePayments install action with services handoff

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/index.js
@@ -1,4 +1,8 @@
 import template from './sw-extension-store-detail.html.twig';
+import {
+    getLegacyServicesExtensionRoute,
+    isLegacyServicesExtension,
+} from 'SwagExtensionStore/util/legacy-services-extension';
 import './sw-extension-store-detail.scss';
 
 const { Utils } = Shopware;
@@ -187,6 +191,14 @@ export default {
 
             return !!this.extension.addons.find(addon => addon === 'SW6_EnterpriseFeature');
         },
+
+        isLegacyServicesExtension() {
+            if (this.suspended) {
+                return false;
+            }
+
+            return isLegacyServicesExtension(this.extension.name);
+        },
     },
 
     watch: {
@@ -359,6 +371,12 @@ export default {
         },
 
         async handleInstallWithPermissionsModal() {
+            if (this.isLegacyServicesExtension) {
+                this.openLegacyServicesExtension();
+
+                return;
+            }
+
             if (Object.keys(this.extension.permissions).length) {
                 this.openAcceptPermissionsModal();
 
@@ -370,6 +388,12 @@ export default {
         },
 
         async installExtension() {
+            if (this.isLegacyServicesExtension) {
+                this.openLegacyServicesExtension();
+
+                return;
+            }
+
             this.isInstalling = true;
 
             try {
@@ -419,6 +443,14 @@ export default {
             }
 
             this.$router.push({ name: 'sw.extension.my-extensions.listing.app' });
+        },
+
+        openLegacyServicesExtension() {
+            const route = getLegacyServicesExtensionRoute(this.extension?.name);
+
+            if (route) {
+                this.$router.push(route);
+            }
         },
 
         checkDescriptionCollapsed() {

--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.html.twig
@@ -207,8 +207,25 @@
 
                         <template v-else-if="isLicensed">
                             {% block sw_extension_store_detail_smart_bar_actions_install %}
+                                <div
+                                    v-if="!isInstalled && isLegacyServicesExtension"
+                                    class="sw-extension-store-detail__services-handoff"
+                                >
+                                    <span class="sw-extension-store-detail__services-handoff-text">
+                                        {{ $t('sw-extension-store.legacyServices.description') }}
+                                    </span>
+
+                                    <mt-button
+                                        variant="primary"
+                                        class="sw-extension-store-detail__action-open-services"
+                                        @click="openLegacyServicesExtension"
+                                    >
+                                        {{ $t('sw-extension-store.legacyServices.openServices') }}
+                                    </mt-button>
+                                </div>
+
                                 <sw-button-process
-                                    v-if="!isInstalled"
+                                    v-else-if="!isInstalled"
                                     variant="primary"
                                     :is-loading="isInstalling"
                                     :process-success="isInstallSuccessful"

--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
@@ -144,7 +144,6 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
     });
 
     beforeEach(() => {
-        Shopware.Context.app.config.version = '6.6.9.9';
         Shopware.Store.get('session').languageId = 'b2c3d4';
         Shopware.Store.get('shopwareExtensions').myExtensions = {
             loading: false,
@@ -342,8 +341,7 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
                 .toBe('sw-extension-store.detail.labelButtonInstallExtension');
         });
 
-        it('renders a Shopware Services handoff for licensed Shopware Payments on 6.7+', async () => {
-            Shopware.Context.app.config.version = '6.7.0.0';
+        it('renders a Shopware Services handoff for licensed Shopware Payments', async () => {
             Shopware.Store.get('shopwareExtensions').myExtensions = {
                 data: [{
                     active: true,
@@ -368,7 +366,6 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
         });
 
         it('routes the Shopware Services handoff to the Shopware Payments administration module', async () => {
-            Shopware.Context.app.config.version = '6.7.0.0';
             Shopware.Store.get('shopwareExtensions').myExtensions = {
                 data: [{
                     active: true,
@@ -396,8 +393,7 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
             });
         });
 
-        it('does not start the Store install flow for guarded Shopware Payments install methods on 6.7+', async () => {
-            Shopware.Context.app.config.version = '6.7.0.0';
+        it('does not start the Store install flow for guarded Shopware Payments install methods', async () => {
             Shopware.Store.get('shopwareExtensions').myExtensions = {
                 data: [{
                     active: true,
@@ -421,32 +417,7 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
             expect(router.push).toHaveBeenCalledTimes(2);
         });
 
-        it('keeps the regular install button for Shopware Payments below 6.7', async () => {
-            Shopware.Context.app.config.version = '6.6.9.9';
-            Shopware.Store.get('shopwareExtensions').myExtensions = {
-                data: [{
-                    active: true,
-                    name: 'ShopwarePayments',
-                    storeLicense: { variants: [{}] },
-                    id: 1337,
-                }],
-            };
-
-            const wrapper = await createWrapper({
-                label: 'Shopware Payments',
-                name: 'ShopwarePayments',
-                type: 'app',
-            });
-            await flushPromises();
-
-            expect(wrapper.find('.sw-extension-store-detail__services-handoff').exists()).toBe(false);
-            expect(wrapper.get('.sw-extension-store-detail__action-install-extension').text())
-                .toBe('sw-extension-store.detail.labelButtonInstallExtension');
-        });
-
-        it('keeps the regular install button for other licensed apps on 6.7+', async () => {
-            Shopware.Context.app.config.version = '6.7.0.0';
-
+        it('keeps the regular install button for other licensed apps', async () => {
             const wrapper = await createWrapper({ type: 'app' });
             await flushPromises();
 

--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
@@ -16,6 +16,10 @@ const extensionHelperService = {
     downloadAndActivateExtension: jest.fn(() => Promise.resolve()),
 };
 
+const router = {
+    push: jest.fn(),
+};
+
 async function createWrapper(extensionCustomProps = {}, canBeOpened = true, inAppPurchases = true) {
     const testExtension = {
         id: 1337,
@@ -90,6 +94,9 @@ async function createWrapper(extensionCustomProps = {}, canBeOpened = true, inAp
                 'sw-external-link': true,
                 'sw-app-topbar-sidebar': true,
             },
+            mocks: {
+                $router: router,
+            },
             provide: {
                 shopwareExtensionService: {
                     updateExtensionData: jest.fn(),
@@ -137,6 +144,7 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
     });
 
     beforeEach(() => {
+        Shopware.Context.app.config.version = '6.6.9.9';
         Shopware.Store.get('session').languageId = 'b2c3d4';
         Shopware.Store.get('shopwareExtensions').myExtensions = {
             loading: false,
@@ -149,6 +157,10 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
         };
 
         setSearchValueMock.mockClear();
+        extensionHelperService.downloadAndActivateExtension.mockClear();
+        cacheApiService.clear.mockClear();
+        window.location.reload.mockClear();
+        router.push.mockClear();
     });
 
     afterEach(() => {
@@ -326,6 +338,119 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
             const wrapper = await createWrapper();
             await flushPromises();
 
+            expect(wrapper.get('.sw-extension-store-detail__action-install-extension').text())
+                .toBe('sw-extension-store.detail.labelButtonInstallExtension');
+        });
+
+        it('renders a Shopware Services handoff for licensed Shopware Payments on 6.7+', async () => {
+            Shopware.Context.app.config.version = '6.7.0.0';
+            Shopware.Store.get('shopwareExtensions').myExtensions = {
+                data: [{
+                    active: true,
+                    name: 'ShopwarePayments',
+                    storeLicense: { variants: [{}] },
+                    id: 1337,
+                }],
+            };
+
+            const wrapper = await createWrapper({
+                label: 'Shopware Payments',
+                name: 'ShopwarePayments',
+                type: 'app',
+            });
+            await flushPromises();
+
+            expect(wrapper.find('.sw-extension-store-detail__action-install-extension').exists()).toBe(false);
+            expect(wrapper.get('.sw-extension-store-detail__services-handoff-text').text())
+                .toBe('sw-extension-store.legacyServices.description');
+            expect(wrapper.get('.sw-extension-store-detail__action-open-services').text())
+                .toBe('sw-extension-store.legacyServices.openServices');
+        });
+
+        it('routes the Shopware Services handoff to the Shopware Payments administration module', async () => {
+            Shopware.Context.app.config.version = '6.7.0.0';
+            Shopware.Store.get('shopwareExtensions').myExtensions = {
+                data: [{
+                    active: true,
+                    name: 'ShopwarePayments',
+                    storeLicense: { variants: [{}] },
+                    id: 1337,
+                }],
+            };
+
+            const wrapper = await createWrapper({
+                label: 'Shopware Payments',
+                name: 'ShopwarePayments',
+                type: 'app',
+            });
+            await flushPromises();
+
+            await wrapper.get('.sw-extension-store-detail__action-open-services').trigger('click');
+
+            expect(router.push).toHaveBeenCalledWith({
+                name: 'sw.extension.module',
+                params: {
+                    appName: 'ShopwarePayments',
+                    moduleName: 'sw-shopware-payments-overview',
+                },
+            });
+        });
+
+        it('does not start the Store install flow for guarded Shopware Payments install methods on 6.7+', async () => {
+            Shopware.Context.app.config.version = '6.7.0.0';
+            Shopware.Store.get('shopwareExtensions').myExtensions = {
+                data: [{
+                    active: true,
+                    name: 'ShopwarePayments',
+                    storeLicense: { variants: [{}] },
+                    id: 1337,
+                }],
+            };
+
+            const wrapper = await createWrapper({
+                label: 'Shopware Payments',
+                name: 'ShopwarePayments',
+                type: 'app',
+            });
+            await flushPromises();
+
+            await wrapper.vm.handleInstallWithPermissionsModal();
+            await wrapper.vm.installExtension();
+
+            expect(extensionHelperService.downloadAndActivateExtension).not.toHaveBeenCalled();
+            expect(router.push).toHaveBeenCalledTimes(2);
+        });
+
+        it('keeps the regular install button for Shopware Payments below 6.7', async () => {
+            Shopware.Context.app.config.version = '6.6.9.9';
+            Shopware.Store.get('shopwareExtensions').myExtensions = {
+                data: [{
+                    active: true,
+                    name: 'ShopwarePayments',
+                    storeLicense: { variants: [{}] },
+                    id: 1337,
+                }],
+            };
+
+            const wrapper = await createWrapper({
+                label: 'Shopware Payments',
+                name: 'ShopwarePayments',
+                type: 'app',
+            });
+            await flushPromises();
+
+            expect(wrapper.find('.sw-extension-store-detail__services-handoff').exists()).toBe(false);
+            expect(wrapper.get('.sw-extension-store-detail__action-install-extension').text())
+                .toBe('sw-extension-store.detail.labelButtonInstallExtension');
+        });
+
+        it('keeps the regular install button for other licensed apps on 6.7+', async () => {
+            Shopware.Context.app.config.version = '6.7.0.0';
+
+            const wrapper = await createWrapper({ type: 'app' });
+            await flushPromises();
+
+            expect(wrapper.find('.sw-extension-store-detail__services-handoff').exists()).toBe(false);
             expect(wrapper.get('.sw-extension-store-detail__action-install-extension').text())
                 .toBe('sw-extension-store.detail.labelButtonInstallExtension');
         });

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/de.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/de.json
@@ -86,6 +86,10 @@
         },
         "in-app-purchases": {
             "onceOff": "einmalig"
+        },
+        "legacyServices": {
+            "description": "Diese Erweiterung ist jetzt als Shopware Service verfügbar.",
+            "openServices": "Shopware Payments öffnen"
         }
     },
     "sw-extension-store-statistics-promotion": {

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/en.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/en.json
@@ -86,6 +86,10 @@
         },
         "in-app-purchases": {
             "onceOff": "one-time"
+        },
+        "legacyServices": {
+            "description": "This extension is now available as a Shopware Service.",
+            "openServices": "Open Shopware Payments"
         }
     },
     "sw-extension-store-statistics-promotion": {

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.ts
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.ts
@@ -1,5 +1,9 @@
 import template from './sw-extension-card-base.html.twig';
 import type * as IAP from 'SwagExtensionStore/module/sw-in-app-purchases/types';
+import {
+    getLegacyServicesExtensionRoute,
+    isLegacyServicesExtension,
+} from 'SwagExtensionStore/util/legacy-services-extension';
 import './sw-extension-card-base.scss';
 
 const accountUrl = 'https://account.shopware.com';
@@ -21,9 +25,44 @@ export default Shopware.Component.wrapComponentConfig({
         };
     },
 
+    computed: {
+        isLegacyServicesExtension() {
+            return isLegacyServicesExtension((this.extension as IAP.Extension).name);
+        },
+    },
+
     methods: {
         openAccountPage() {
             window.open(`${accountUrl}/shops/shops`, '_blank');
+        },
+
+        openLegacyServicesExtension() {
+            const route = getLegacyServicesExtensionRoute((this.extension as IAP.Extension).name);
+
+            if (route) {
+                this.$router.push(route);
+            }
+        },
+
+        async openPermissionsModalForInstall() {
+            if (this.isLegacyServicesExtension) {
+                this.openLegacyServicesExtension();
+
+                return;
+            }
+
+            if (!this.permissions) {
+                this.permissionsAccepted = true;
+                this.isLoading = true;
+                await (this as unknown as { installAndActivateExtension: () => Promise<void> }).installAndActivateExtension();
+
+                return;
+            }
+
+            this.permissionModalActionLabel = this.$t(
+                'sw-extension-store.component.sw-extension-card-base.labelAcceptAndInstall',
+            );
+            this.showPermissionsModal = true;
         },
 
         hasActiveInAppPurchases(extensionName: string) {

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -9,6 +9,16 @@
             {{ $t('sw-extension.in-app-purchase.badge-label') }}
         </span>
     </section>
+
+    <button
+        v-if="!isInstalled && isLegacyServicesExtension"
+        class="sw-extension-card-base__open-services"
+        type="button"
+        @click="openLegacyServicesExtension"
+        @keydown.enter="openLegacyServicesExtension"
+    >
+        {{ $t('sw-extension-store.legacyServices.openServices') }}
+    </button>
 </div>
 {% endblock %}
 

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
@@ -3,3 +3,21 @@
     justify-content: space-between;
     align-items: center;
 }
+
+.sw-extension-card-base:has(.sw-extension-card-base__open-services) {
+    .sw-extension-card-base__main-action {
+        .sw-extension-card-base__open-extension {
+            display: none;
+        }
+    }
+}
+
+.sw-extension-card-base__open-services {
+    margin: 8px 0 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: #189eff;
+    cursor: pointer;
+    font: inherit;
+}

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
@@ -98,7 +98,6 @@ async function createWrapper(extensionCustomProps = {}) {
 
 describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => {
     beforeEach(() => {
-        Shopware.Context.app.config.version = '6.6.9.9';
         router.push.mockClear();
     });
 
@@ -175,9 +174,7 @@ describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => 
         ]);
     });
 
-    it('replaces the install action with a Shopware Services handoff for Shopware Payments on 6.7+', async () => {
-        Shopware.Context.app.config.version = '6.7.0.0';
-
+    it('replaces the install action with a Shopware Services handoff for Shopware Payments', async () => {
         const wrapper = await createWrapper({
             label: 'Shopware Payments',
             name: 'ShopwarePayments',
@@ -192,8 +189,6 @@ describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => 
     });
 
     it('routes to the Shopware Payments administration module from the services handoff', async () => {
-        Shopware.Context.app.config.version = '6.7.0.0';
-
         const wrapper = await createWrapper({
             label: 'Shopware Payments',
             name: 'ShopwarePayments',
@@ -215,25 +210,7 @@ describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => 
         });
     });
 
-    it('keeps the regular install action for Shopware Payments below 6.7', async () => {
-        Shopware.Context.app.config.version = '6.6.9.9';
-
-        const wrapper = await createWrapper({
-            label: 'Shopware Payments',
-            name: 'ShopwarePayments',
-            installedAt: null,
-            storeLicense: { creationDate: new Date(), variants: [{}] },
-            type: 'app',
-        });
-
-        expect(wrapper.find('.sw-extension-card-base__open-services').exists()).toBe(false);
-        expect(wrapper.find('.sw-extension-card-base__open-extension').text())
-            .toBe('sw-extension-store.component.sw-extension-card-base.installExtensionLabel');
-    });
-
-    it('keeps the regular install action for other licensed apps on 6.7+', async () => {
-        Shopware.Context.app.config.version = '6.7.0.0';
-
+    it('keeps the regular install action for other licensed apps', async () => {
         const wrapper = await createWrapper({
             name: 'SwagB2BPlatform',
             installedAt: null,

--- a/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
@@ -17,6 +17,10 @@ Shopware.Store.get('context').app = {
     },
 };
 
+const router = {
+    push: jest.fn(),
+};
+
 async function createWrapper(extensionCustomProps = {}) {
     const testExtension = {
         id: 1337,
@@ -67,6 +71,10 @@ async function createWrapper(extensionCustomProps = {}) {
                 'sw-internal-link': true,
                 'sw-extension-store-in-app-purchases-listing-modal': true,
                 'sw-time-ago': true,
+                'mt-switch': true,
+            },
+            mocks: {
+                $router: router,
             },
             provide: {
                 shopwareExtensionService: {
@@ -89,6 +97,11 @@ async function createWrapper(extensionCustomProps = {}) {
 }
 
 describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => {
+    beforeEach(() => {
+        Shopware.Context.app.config.version = '6.6.9.9';
+        router.push.mockClear();
+    });
+
     it('should be a Vue.js component', async () => {
         const wrapper = await createWrapper({ inAppFeaturesAvailable: true });
 
@@ -160,5 +173,76 @@ describe('SwagExtensionStore/module/sw-extension/component/sw-extension', () => 
             { id: 'purchase1', name: 'Purchase 1' },
             { id: 'purchase2', name: 'Purchase 2' },
         ]);
+    });
+
+    it('replaces the install action with a Shopware Services handoff for Shopware Payments on 6.7+', async () => {
+        Shopware.Context.app.config.version = '6.7.0.0';
+
+        const wrapper = await createWrapper({
+            label: 'Shopware Payments',
+            name: 'ShopwarePayments',
+            installedAt: null,
+            storeLicense: { creationDate: new Date(), variants: [{}] },
+            type: 'app',
+        });
+
+        expect(wrapper.find('.sw-extension-card-base__open-services').exists()).toBe(true);
+        expect(wrapper.find('.sw-extension-card-base__open-services').text())
+            .toBe('sw-extension-store.legacyServices.openServices');
+    });
+
+    it('routes to the Shopware Payments administration module from the services handoff', async () => {
+        Shopware.Context.app.config.version = '6.7.0.0';
+
+        const wrapper = await createWrapper({
+            label: 'Shopware Payments',
+            name: 'ShopwarePayments',
+            installedAt: null,
+            storeLicense: { creationDate: new Date(), variants: [{}] },
+            type: 'app',
+        });
+
+        await wrapper.find('.sw-extension-card-base__open-services').trigger('click');
+        await wrapper.find('.sw-extension-card-base__open-services').trigger('keydown.enter');
+
+        expect(router.push).toHaveBeenCalledTimes(2);
+        expect(router.push).toHaveBeenNthCalledWith(1, {
+            name: 'sw.extension.module',
+            params: {
+                appName: 'ShopwarePayments',
+                moduleName: 'sw-shopware-payments-overview',
+            },
+        });
+    });
+
+    it('keeps the regular install action for Shopware Payments below 6.7', async () => {
+        Shopware.Context.app.config.version = '6.6.9.9';
+
+        const wrapper = await createWrapper({
+            label: 'Shopware Payments',
+            name: 'ShopwarePayments',
+            installedAt: null,
+            storeLicense: { creationDate: new Date(), variants: [{}] },
+            type: 'app',
+        });
+
+        expect(wrapper.find('.sw-extension-card-base__open-services').exists()).toBe(false);
+        expect(wrapper.find('.sw-extension-card-base__open-extension').text())
+            .toBe('sw-extension-store.component.sw-extension-card-base.installExtensionLabel');
+    });
+
+    it('keeps the regular install action for other licensed apps on 6.7+', async () => {
+        Shopware.Context.app.config.version = '6.7.0.0';
+
+        const wrapper = await createWrapper({
+            name: 'SwagB2BPlatform',
+            installedAt: null,
+            storeLicense: { creationDate: new Date(), variants: [{}] },
+            type: 'app',
+        });
+
+        expect(wrapper.find('.sw-extension-card-base__open-services').exists()).toBe(false);
+        expect(wrapper.find('.sw-extension-card-base__open-extension').text())
+            .toBe('sw-extension-store.component.sw-extension-card-base.installExtensionLabel');
     });
 });

--- a/src/Resources/app/administration/src/util/legacy-services-extension.ts
+++ b/src/Resources/app/administration/src/util/legacy-services-extension.ts
@@ -1,0 +1,40 @@
+const MINIMUM_SERVICES_VERSION = '6.7.0.0';
+
+const LEGACY_SERVICES_EXTENSIONS = {
+    ShopwarePayments: {
+        route: {
+            name: 'sw.extension.module',
+            params: {
+                appName: 'ShopwarePayments',
+                moduleName: 'sw-shopware-payments-overview',
+            },
+        },
+    },
+};
+
+type LegacyServicesExtensionName = keyof typeof LEGACY_SERVICES_EXTENSIONS;
+
+function getCleanShopwareVersion(): string {
+    return (Shopware.Context.app.config.version ?? '').replace(/-.*/, '');
+}
+
+export function isAtLeastShopware67(): boolean {
+    return getCleanShopwareVersion()
+        .localeCompare(MINIMUM_SERVICES_VERSION, undefined, { numeric: true }) >= 0;
+}
+
+export function isLegacyServicesExtension(extensionName?: string): boolean {
+    if (!extensionName) {
+        return false;
+    }
+
+    return isAtLeastShopware67() && extensionName in LEGACY_SERVICES_EXTENSIONS;
+}
+
+export function getLegacyServicesExtensionRoute(extensionName?: string) {
+    if (!isLegacyServicesExtension(extensionName)) {
+        return null;
+    }
+
+    return LEGACY_SERVICES_EXTENSIONS[extensionName as LegacyServicesExtensionName].route;
+}

--- a/src/Resources/app/administration/src/util/legacy-services-extension.ts
+++ b/src/Resources/app/administration/src/util/legacy-services-extension.ts
@@ -1,5 +1,3 @@
-const MINIMUM_SERVICES_VERSION = '6.7.0.0';
-
 const LEGACY_SERVICES_EXTENSIONS = {
     ShopwarePayments: {
         route: {
@@ -14,21 +12,12 @@ const LEGACY_SERVICES_EXTENSIONS = {
 
 type LegacyServicesExtensionName = keyof typeof LEGACY_SERVICES_EXTENSIONS;
 
-function getCleanShopwareVersion(): string {
-    return (Shopware.Context.app.config.version ?? '').replace(/-.*/, '');
-}
-
-export function isAtLeastShopware67(): boolean {
-    return getCleanShopwareVersion()
-        .localeCompare(MINIMUM_SERVICES_VERSION, undefined, { numeric: true }) >= 0;
-}
-
 export function isLegacyServicesExtension(extensionName?: string): boolean {
     if (!extensionName) {
         return false;
     }
 
-    return isAtLeastShopware67() && extensionName in LEGACY_SERVICES_EXTENSIONS;
+    return extensionName in LEGACY_SERVICES_EXTENSIONS;
 }
 
 export function getLegacyServicesExtensionRoute(extensionName?: string) {


### PR DESCRIPTION
Prevents ShopwarePayments from starting the Store app install flow on 6.7+ and replaces it with a handoff CTA to the ShopwarePayments administration module.

Please see https://github.com/shopware/SwagExtensionStore/issues/172