### PR TITLE
[Issue 185] Fix Binary Changelog version ordering 

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/index.js
@@ -163,7 +163,9 @@ export default {
         },
 
         orderedBinaries() {
-            return Utils.get(this.extension, 'binaries', []).slice().reverse();
+            return Utils.get(this.extension, 'binaries', []).slice().sort((a, b) => {
+                return String(b.version ?? '').localeCompare(String(a.version ?? ''), undefined, { numeric: true });
+            });
         },
 
         priceClass() {

--- a/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/page/sw-extension-store-detail/sw-extension-store-detail.spec.js
@@ -177,6 +177,22 @@ describe('SwagExtensionStore/module/sw-extension-store/page/sw-extension-store-d
         expect(wrapper.vm.extensionCategoryNames).toBe('Productivity, Admin, Storefront');
     });
 
+    it('should order changelog binaries by numeric version descending', async () => {
+        const wrapper = await createWrapper({
+            binaries: [
+                { version: '2.8.0' },
+                { version: '2.10.0' },
+                { version: '2.9.0' },
+            ],
+        });
+
+        expect(wrapper.vm.orderedBinaries.map((binary) => binary.version)).toEqual([
+            '2.10.0',
+            '2.9.0',
+            '2.8.0',
+        ]);
+    });
+
     it('should render alert box when extension is an enterprise feature', async () => {
         Shopware.Store.get('shopwareExtensions').myExtensions = {
             data: [{


### PR DESCRIPTION
+ Fixes how binary versions should be ordered so that minor versions such as 2.10.0 so they are not treated as 2.1.0.