### PR TITLE
chore: update PHPStan ignores for v6.8 deprecations

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -31,6 +31,10 @@ parameters:
             message: '#deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
             path: tests/Controller/InAppPurchasesControllerTest.php
 
+        -
+            message: '#Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
+            path: src/Controller/InAppPurchasesController.php
+
 
 rules:
     # Shopware core rules

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,15 @@ parameters:
             message: '#Call to deprecated method set\(\) of class Shopware\\Core\\System\\SystemConfig\\SystemConfigService#'
             path: tests
 
+        -
+            message: '#Call to deprecated method scope\(\) of class Shopware\\Core\\Framework\\Context:#'
+            path: src/Controller/InAppPurchasesController.php
+
+        -
+            message: '#deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
+            path: tests/Controller/InAppPurchasesControllerTest.php
+
+
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule


### PR DESCRIPTION
Adjusts PHPStan ignores in `phpstan.neon.dist` for Shopware v6.8 deprecation errors related to `Context::scope()` and `EntitySearchResult`.