### PR TITLE
fix: unbreak PHPStan EntitySearchResult deprecations

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,13 +19,11 @@ parameters:
             message: '#Service ".*" is private#'
             path: tests
 
+        # EntitySearchResult::__construct is deprecated until v6.8 removes $entity and reorders params.
+        # Test fixtures still need the current signature on 6.7; silence until platform bumps.
         -
-            message: '#deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
+            message: '#Call to deprecated method __construct\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult#'
             path: tests/Controller/InAppPurchasesControllerTest.php
-
-        -
-            message: '#Call to method getEntities\(\) of deprecated class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
-            path: src/Controller/InAppPurchasesController.php
 
 
 rules:

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
@@ -452,14 +451,13 @@ class InAppPurchasesControllerTest extends TestCase
         $app->setName('TestName');
         $app->setUniqueIdentifier(Uuid::randomHex());
 
-        // EntitySearchResult still accepts $entity on 6.7; removed in 6.8 (UPGRADE-6.8.md).
-        return Feature::silent('v6.8.0.0', static fn () => new EntitySearchResult(
+        return new EntitySearchResult(
             'app',
             1,
             new EntityCollection([$app]),
             null,
             new Criteria(),
             Context::createDefaultContext(),
-        ));
+        );
     }
 }

--- a/tests/Controller/InAppPurchasesControllerTest.php
+++ b/tests/Controller/InAppPurchasesControllerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
@@ -451,13 +452,14 @@ class InAppPurchasesControllerTest extends TestCase
         $app->setName('TestName');
         $app->setUniqueIdentifier(Uuid::randomHex());
 
-        return new EntitySearchResult(
-            'aoo',
+        // EntitySearchResult still accepts $entity on 6.7; removed in 6.8 (UPGRADE-6.8.md).
+        return Feature::silent('v6.8.0.0', static fn () => new EntitySearchResult(
+            'app',
             1,
             new EntityCollection([$app]),
             null,
             new Criteria(),
             Context::createDefaultContext(),
-        );
+        ));
     }
 }


### PR DESCRIPTION
## What changed?

Fixes the failing scheduled **Static Analyse** job:
https://github.com/shopware/SwagExtensionStore/actions/runs/30327480501/job/90175768778

### CI failures
1. Ignored error patterns no longer matched:
   - `getEntities()` of deprecated `EntitySearchResult` (controller path)
   - deprecated class `EntitySearchResult` (test path)
2. Real error: **deprecated `EntitySearchResult::__construct()`** in `InAppPurchasesControllerTest`

### Root cause
Shopware trunk 6.8 deprecations shifted: `getEntities()` is the supported API (UPGRADE-6.8), while constructing `EntitySearchResult` with the old `$entity` parameter is deprecated. Ignores from #188 targeted the old messages.

### Fix
- Remove stale `ignoreErrors` in `phpstan.neon.dist`
- Ignore only `EntitySearchResult::__construct` deprecation in the test fixture (still needed on 6.7)
- Wrap fixture construction in `Feature::silent('v6.8.0.0', …)` and correct `'aoo'` → `'app'`
- Controller already uses `->getEntities()->first()` — left as-is

## How was this tested?

- Aligned with the failed job log (unmatched ignores + constructor deprecation)
- `php -l` on the touched test file
- CI Static Analyse on this PR will confirm

## Related

Scheduled run: https://github.com/shopware/SwagExtensionStore/actions/runs/30327480501