### PR TITLE
ECTO-2770 - ECTO-2770 - Report the real purchase result when the moda…

### DIFF
--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.spec.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.spec.ts
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils';
 import { handle, publish } from '@shopware-ag/meteor-admin-sdk/es/channel';
 import { ExtensionStoreChannelService } from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-channel.service';
 import extensionStorePurchaseConfirmationStore from 'SwagExtensionStore/module/sw-extension-store/store/extension-store-purchase-confirmation.store';
@@ -76,7 +77,11 @@ describe('SwagExtensionStore/module/sw-extension-store/service/extension-store-c
             extensionStoreLicensesService as never,
             extensionHelperService as never,
             cacheApiService as never,
-            { push: jest.fn(), currentRoute: { value: { params: {}, query: {} } } } as never,
+            {
+                push: jest.fn(),
+                afterEach: jest.fn(() => jest.fn()),
+                currentRoute: { value: { params: {}, query: {} } },
+            } as never,
             extensionStorePreferencesService as never,
         );
     };
@@ -146,6 +151,37 @@ describe('SwagExtensionStore/module/sw-extension-store/service/extension-store-c
             await performPurchase();
 
             expect(cacheApiService.clear).toHaveBeenCalledTimes(1);
+        });
+
+        it('should publish the successful result when the modal is closed while installing', async () => {
+            let finishInstallation = (): void => {};
+            extensionHelperService.downloadAndActivateExtension.mockReturnValue(new Promise((resolve) => {
+                finishInstallation = () => resolve(undefined);
+            }));
+
+            service.register();
+            const channelHandler = handleMock.mock.calls[0][1] as (data: unknown) => Promise<unknown>;
+            await channelHandler(purchaseActionData);
+
+            const store = extensionStorePurchaseConfirmationStore();
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            // The user closes the modal while the extension is being installed.
+            store.cancel();
+
+            expect(publishMock).not.toHaveBeenCalled();
+
+            finishInstallation();
+            await confirmed;
+
+            expect(publishMock).toHaveBeenCalledTimes(1);
+            expect(publishMock).toHaveBeenCalledWith('swag-extension-store-channel', {
+                action: 'purchaseResult',
+                sessionToken: 'session-token',
+                success: true,
+                extensionVersion: '2.1.0',
+            });
         });
 
         it('should still request a reload when clearing the cache fails', async () => {

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/de.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/de.json
@@ -104,7 +104,10 @@
             "successTitle": "Installation erfolgreich",
             "successMessage": "{name} wurde erfolgreich installiert und aktiviert.",
             "errorTitle": "Installation fehlgeschlagen",
-            "errorMessage": "{name} konnte nicht installiert werden. Bitte versuche es erneut oder installiere es manuell."
+            "errorMessage": "{name} konnte nicht installiert werden. Bitte versuche es erneut oder installiere es manuell.",
+            "reloadRequiredTitle": "Neuladen erforderlich",
+            "reloadRequiredMessage": "{name} wurde installiert. Lade die Administration neu, um es zu verwenden.",
+            "reloadRequiredAction": "Jetzt neu laden"
         }
     }
 }

--- a/src/Resources/app/administration/src/module/sw-extension-store/snippet/en.json
+++ b/src/Resources/app/administration/src/module/sw-extension-store/snippet/en.json
@@ -104,7 +104,10 @@
             "successTitle": "Installation successful",
             "successMessage": "{name} has been successfully installed and activated.",
             "errorTitle": "Installation failed",
-            "errorMessage": "{name} could not be installed. Please try again or install it manually."
+            "errorMessage": "{name} could not be installed. Please try again or install it manually.",
+            "reloadRequiredTitle": "Reload required",
+            "reloadRequiredMessage": "{name} has been installed. Reload the administration to start using it.",
+            "reloadRequiredAction": "Reload now"
         }
     }
 }

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-purchase-confirmation.store.spec.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-purchase-confirmation.store.spec.ts
@@ -38,14 +38,40 @@ const openModalWith = (result: PurchaseConfirmationOnConfirmCallbackResult | Pro
     });
 };
 
+/** Opens the modal with a purchase that only finishes once the returned `finishPurchase` is called. */
+const openModalWithPendingPurchase = (result: PurchaseConfirmationOnConfirmCallbackResult) => {
+    let finishPurchase = (): void => {};
+    const onCancel = jest.fn();
+
+    extensionStorePurchaseConfirmationStore().openModal({
+        cart,
+        paymentMeans: [],
+        isCompatible: true,
+        onConfirm: () => new Promise((resolve) => {
+            finishPurchase = () => resolve(result);
+        }),
+        onCancel,
+    });
+
+    return {
+        onCancel,
+        finishPurchase: () => finishPurchase(),
+    };
+};
+
 describe('SwagExtensionStore/module/sw-extension-store/store/extension-store-purchase-confirmation.store', () => {
     let reloadAfterSpy: jest.SpyInstance;
+    let reloadSpy: jest.SpyInstance;
+    let createNotificationSpy: jest.SpyInstance;
 
     beforeEach(() => {
         extensionStorePurchaseConfirmationStore().$reset();
         trackMock.mockClear();
         trackMock.mockImplementation(() => Promise.resolve());
         reloadAfterSpy = jest.spyOn(pageReload, 'reloadAfter').mockResolvedValue();
+        reloadSpy = jest.spyOn(pageReload, 'reload').mockImplementation(() => {});
+        createNotificationSpy = jest.spyOn(Shopware.Store.get('notification'), 'createNotification')
+            .mockImplementation(() => null);
     });
 
     afterEach(() => {
@@ -112,6 +138,102 @@ describe('SwagExtensionStore/module/sw-extension-store/store/extension-store-pur
             expect(reloadAfterSpy).not.toHaveBeenCalled();
         });
 
+        it('should not reload the page when the modal was closed while the purchase was in progress', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: true });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            // The user closes the modal and possibly navigates away while the purchase is still running.
+            store.closeModal();
+            finishPurchase();
+            await confirmed;
+
+            expect(store.isOpen).toBe(false);
+            expect(store.isLoading).toBe(false);
+            expect(reloadAfterSpy).not.toHaveBeenCalled();
+        });
+
+        it('should offer the reload when the modal was closed while the extension was installed', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: true });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            store.closeModal();
+            finishPurchase();
+            await confirmed;
+
+            expect(createNotificationSpy).toHaveBeenCalledTimes(1);
+            expect(createNotificationSpy).toHaveBeenCalledWith(expect.objectContaining({
+                variant: 'info',
+                growl: true,
+                autoClose: false,
+            }));
+
+            // The notification offers the reload the store did not perform on its own.
+            const notification = createNotificationSpy.mock.calls[0][0] as {
+                actions: { method: () => void }[];
+            };
+            expect(reloadSpy).not.toHaveBeenCalled();
+
+            notification.actions[0].method();
+
+            expect(reloadSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not reload the page when another purchase was started in the meantime', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: true });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            // The user closes the modal and starts another purchase while the first one is still running.
+            store.closeModal();
+            openModalWith({ success: true });
+            finishPurchase();
+            await confirmed;
+
+            expect(store.isOpen).toBe(true);
+            expect(reloadAfterSpy).not.toHaveBeenCalled();
+            expect(createNotificationSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not offer the reload when nothing was installed', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: false });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            store.closeModal();
+            finishPurchase();
+            await confirmed;
+
+            expect(createNotificationSpy).not.toHaveBeenCalled();
+        });
+
+        it('should track the purchase result when the modal was closed while the purchase was in progress', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: true });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            // `closeModal` resets the cart, the tracked event must still contain the purchased extension.
+            store.closeModal();
+            finishPurchase();
+            await confirmed;
+
+            expect(trackMock).toHaveBeenCalledWith('extension_purchase_successful', expect.objectContaining({
+                extension_id: 'extension-id',
+                extension_name: 'SwagApp',
+            }));
+        });
+
         it('should not reload the page when the purchase failed', async () => {
             openModalWith({
                 success: false,
@@ -131,6 +253,102 @@ describe('SwagExtensionStore/module/sw-extension-store/store/extension-store-pur
             expect(store.errorDocumentationLink).toBe('error-link');
             expect(trackMock).toHaveBeenCalledWith('extension_purchase_failed', expect.any(Object));
             expect(reloadAfterSpy).not.toHaveBeenCalled();
+        });
+
+        it('should track the failed purchase when the modal was closed while the purchase was in progress', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { finishPurchase } = openModalWithPendingPurchase({ success: false });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            store.closeModal();
+            finishPurchase();
+            await confirmed;
+
+            expect(trackMock).toHaveBeenCalledWith('extension_purchase_failed', expect.objectContaining({
+                extension_id: 'extension-id',
+            }));
+            expect(createNotificationSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cancel', () => {
+        it('should report the cancellation when the purchase was not confirmed yet', () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { onCancel } = openModalWithPendingPurchase({ success: true });
+
+            store.cancel();
+
+            expect(onCancel).toHaveBeenCalledTimes(1);
+            expect(trackMock).toHaveBeenCalledWith('extension_purchase_cancelled', expect.any(Object));
+            expect(store.isOpen).toBe(false);
+        });
+
+        it('should not report a cancellation while the purchase is still running', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { onCancel, finishPurchase } = openModalWithPendingPurchase({ success: true, requiresReload: true });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+
+            // A running purchase cannot be aborted, so it must not be reported as cancelled either.
+            store.cancel();
+
+            expect(onCancel).not.toHaveBeenCalled();
+            expect(trackMock).not.toHaveBeenCalledWith('extension_purchase_cancelled', expect.anything());
+            expect(store.isOpen).toBe(false);
+
+            finishPurchase();
+            await confirmed;
+        });
+
+        it('should not report a cancellation when closing the result of a failed purchase', async () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const { onCancel, finishPurchase } = openModalWithPendingPurchase({ success: false });
+
+            const confirmed = store.confirm();
+            await flushPromises();
+            finishPurchase();
+            await confirmed;
+
+            // The purchase already reported its failure, closing the result must not report it again.
+            store.cancel();
+
+            expect(onCancel).not.toHaveBeenCalled();
+            expect(trackMock).not.toHaveBeenCalledWith('extension_purchase_cancelled', expect.anything());
+        });
+
+        it('should report the cancellation of a failed basket creation', () => {
+            const store = extensionStorePurchaseConfirmationStore();
+            const onCancel = jest.fn();
+
+            store.openErrorModal('error-title', 'error-description', 'error-link', onCancel);
+            store.cancel();
+
+            expect(store.isFailedOnBasketCreation).toBe(false);
+            expect(onCancel).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('openModal', () => {
+        it('should reset the state of a previous purchase', () => {
+            const store = extensionStorePurchaseConfirmationStore();
+
+            store.isSubmitted = true;
+            store.isSuccessful = true;
+            store.checkoutStep = 'reload';
+            store.errorTitle = 'previous-error';
+            store.isFailedOnBasketCreation = true;
+
+            openModalWith({ success: true });
+
+            expect(store.isOpen).toBe(true);
+            expect(store.isSubmitted).toBe(false);
+            expect(store.isSuccessful).toBe(false);
+            expect(store.checkoutStep).toBeNull();
+            expect(store.errorTitle).toBeNull();
+            expect(store.isFailedOnBasketCreation).toBe(false);
         });
     });
 });

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-purchase-confirmation.store.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-purchase-confirmation.store.ts
@@ -23,6 +23,11 @@ export type PurchaseConfirmationModalData = {
 };
 
 type PurchaseConfirmationState = {
+    /**
+     * Increases with every opened modal. A purchase that outlived its modal uses it to tell whether
+     * the modal currently on screen is still its own.
+     */
+    purchaseId: number;
     isFailedOnBasketCreation: boolean;
     isOpen: boolean;
     isLoading: boolean;
@@ -60,6 +65,38 @@ const trackExtensionStorePurchaseEvent = (
 };
 
 /**
+ * The extension is installed at this point, but the running administration does not know about it
+ * yet. Reloading unprompted would be unexpected while the modal is closed, so the reload is offered
+ * to the user instead.
+ */
+const notifyReloadRequired = (cartData: ExtensionStoreBasket | null): void => {
+    const [position] = cartData?.positions ?? [];
+    if (!position) {
+        return;
+    }
+
+    const snippetService = Shopware.Snippet as unknown as {
+        tc: (key: string, params?: Record<string, string>) => string;
+    };
+
+    Shopware.Store.get('notification').createNotification({
+        variant: 'info',
+        growl: true,
+        autoClose: false,
+        title: snippetService.tc('sw-extension-store.installation.reloadRequiredTitle'),
+        message: snippetService.tc('sw-extension-store.installation.reloadRequiredMessage', {
+            name: String(position.extension.name),
+        }),
+        actions: [
+            {
+                label: snippetService.tc('sw-extension-store.installation.reloadRequiredAction'),
+                method: () => pageReload.reload(),
+            },
+        ],
+    });
+};
+
+/**
  * Duration the 'reload' hint is shown before the page is reloaded. Must stay above the
  * telemetry gateway's flush interval (1s), so the tracked purchase events are sent out
  * before the page is torn down.
@@ -68,6 +105,7 @@ const RELOAD_DELAY_MS = 1_500;
 
 export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
     state: (): PurchaseConfirmationState => ({
+        purchaseId: 0,
         isFailedOnBasketCreation: false,
         isOpen: false,
         isLoading: false,
@@ -86,6 +124,11 @@ export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
 
     actions: {
         openModal(data: PurchaseConfirmationModalData): void {
+            // A previous purchase might still be running detached from its closed modal and write to
+            // the state after it finished. Start from a clean state, so nothing leaks into this modal.
+            this.closeModal();
+
+            this.purchaseId += 1;
             this.cartData = data.cart;
             this.paymentMeansData = data.paymentMeans;
             this.isCompatible = data.isCompatible;
@@ -101,7 +144,12 @@ export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
                 return;
             }
 
-            void trackExtensionStorePurchaseEvent(this.cartData, 'confirmed');
+            // The modal can be closed while the purchase is running, which resets `cartData`. Keep a
+            // reference, so the tracking events below are still dispatched for the purchased extension.
+            const cartData = this.cartData;
+            const purchaseId = this.purchaseId;
+
+            void trackExtensionStorePurchaseEvent(cartData, 'confirmed');
 
             this.isSubmitted = true;
             this.isLoading = true;
@@ -115,32 +163,43 @@ export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
             if (this.isSuccessful) {
                 this.onCancel = null;
                 this.onConfirm = null;
-                trackingDispatched = trackExtensionStorePurchaseEvent(this.cartData, 'successful');
+                trackingDispatched = trackExtensionStorePurchaseEvent(cartData, 'successful');
             } else {
                 this.errorTitle = result.title ?? null;
                 this.errorDescription = result.description ?? null;
                 this.errorDocumentationLink = result.documentationLink ?? null;
-                trackingDispatched = trackExtensionStorePurchaseEvent(this.cartData, 'failed');
+                trackingDispatched = trackExtensionStorePurchaseEvent(cartData, 'failed');
             }
 
             if (this.isSuccessful && result.requiresReload) {
-                // Ensure the tracking event is sent before the page is reloaded, otherwise it will be lost.
-                await trackingDispatched;
-                await pageReload.reloadAfter(RELOAD_DELAY_MS);
+                // Only reload on our own while the modal still shows this purchase. If it was closed,
+                // the user might have navigated away or even started another purchase in the meantime,
+                // where a reload would be unexpected.
+                if (this.isOpen && this.purchaseId === purchaseId) {
+                    // Ensure the tracking event is sent before the page is reloaded, otherwise it will be lost.
+                    await trackingDispatched;
+                    await pageReload.reloadAfter(RELOAD_DELAY_MS);
 
-                return;
+                    return;
+                }
+
+                notifyReloadRequired(cartData);
             }
 
             this.isLoading = false;
         },
 
         cancel(): void {
-            if (this.onCancel) {
-                this.onCancel();
-            }
+            // A submitted purchase cannot be aborted, so closing the modal must neither report a failure
+            // nor track a cancellation. The purchase itself publishes the real result once it finished.
+            if (!this.isSubmitted) {
+                if (this.onCancel) {
+                    this.onCancel();
+                }
 
-            if (!this.isSuccessful) {
-                void trackExtensionStorePurchaseEvent(this.cartData, 'cancelled');
+                if (!this.isSuccessful) {
+                    void trackExtensionStorePurchaseEvent(this.cartData, 'cancelled');
+                }
             }
 
             this.closeModal();
@@ -152,7 +211,7 @@ export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
             this.isSubmitted = false;
             this.checkoutStep = null;
             this.isSuccessful = false;
-            this.isFailedOnBasketCreation =false;
+            this.isFailedOnBasketCreation = false;
             this.cartData = null;
             this.paymentMeansData = null;
             this.onConfirm = null;
@@ -168,6 +227,8 @@ export default Shopware.Store.register('extensionStorePurchaseConfirmation', {
             errorDocumentationLink: string,
             onCancel: PurchaseConfirmationOnCancelCallback,
         ): void {
+            this.closeModal();
+
             this.onCancel = onCancel;
             this.errorTitle = errorTitle;
             this.errorDescription = errorDescription;


### PR DESCRIPTION
…l is closed while installing

- It's possible to close the checkout modal while the installation is ongoing. This would've still triggered an unexpected refresh, even after navigating away.
- After fixing that, I noticed that the buy box doesn't change to "Already owned". That's because closing the modal was emitting a "purchase failed" response to the iframe (and also Amplitude). I fixed that as well.