### PR TITLE
ECTO-2855 - add demo shop status to the Admin Store handshake

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,10 +19,6 @@ parameters:
             message: '#Service ".*" is private#'
             path: tests
 
-        -
-            message: '#Call to deprecated method set\(\) of class Shopware\\Core\\System\\SystemConfig\\SystemConfigService#'
-            path: tests
-
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/src/Controller/DemoShopController.php
+++ b/src/Controller/DemoShopController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Controller;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use SwagExtensionStore\Services\DemoShopService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[Route(defaults: ['_routeScope' => ['api'], '_acl' => ['system.extension_store']])]
+class DemoShopController
+{
+    public function __construct(private readonly DemoShopService $demoShopService)
+    {
+    }
+
+    #[Route('/api/_action/extension-store/demo-shop-information', name: 'api.extension.demo-shop-information', methods: ['GET'])]
+    public function getDemoShopInformation(Context $context): JsonResponse
+    {
+        $demoShopInformation = $this->demoShopService->getDemoShopInformation($context);
+
+        return new JsonResponse([
+            'isDemoShop' => $demoShopInformation !== null,
+            'demoShopInformation' => $demoShopInformation?->toArray(),
+        ]);
+    }
+}

--- a/src/Resources/app/administration/src/global.types.ts
+++ b/src/Resources/app/administration/src/global.types.ts
@@ -6,6 +6,8 @@ import type ExtensionStorePreferencesService
 import type {
     ExtensionStoreChannelService,
 } from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-channel.service';
+import type ExtensionStoreDemoShopService
+    from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-demo-shop.service';
 
 declare global {
     type PropType<T> = TPropType<T>;
@@ -14,6 +16,7 @@ declare global {
         inAppPurchasesService: InAppPurchasesService;
         extensionStoreChannelService: ExtensionStoreChannelService;
         extensionStorePreferencesService: ExtensionStorePreferencesService;
+        extensionStoreDemoShopService: ExtensionStoreDemoShopService;
     }
 
     type ErrorResponse = AxiosError<{ errors: Array<ShopwareHttpError & { apiCode: string }> }>;

--- a/src/Resources/app/administration/src/module/sw-extension-store/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/index.js
@@ -1,4 +1,5 @@
 import ExtensionLicenseService from './service/extension-store-licenses.service';
+import ExtensionStoreDemoShopService from './service/extension-store-demo-shop.service';
 import {
     ExtensionStoreChannelService,
 } from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-channel.service';
@@ -27,6 +28,13 @@ Shopware.Application.addServiceProvider('extensionStoreChannelService', () => {
 
 Shopware.Application.addServiceProvider('extensionStoreLicensesService', () => {
     return new ExtensionLicenseService(
+        Shopware.Application.getContainer('init').httpClient,
+        Shopware.Service('loginService'),
+    );
+});
+
+Shopware.Application.addServiceProvider('extensionStoreDemoShopService', () => {
+    return new ExtensionStoreDemoShopService(
         Shopware.Application.getContainer('init').httpClient,
         Shopware.Service('loginService'),
     );

--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.ts
@@ -15,6 +15,7 @@ import type { TrackableType } from 'src/core/telemetry/types';
 import type ExtensionStorePreferencesService
     from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-preferences.service';
 import type { UserInfo } from 'src/core/service/api/store.api.service';
+import type { DemoShopInformation } from '../types/extension-store-demo-shop.types';
 
 type StoreChannelAction = 'handshake' | 'routeTo' | 'purchase' | 'routerUpdate' | 'copyToClipboard' | 'trackEvent';
 
@@ -66,6 +67,8 @@ type StoreContext = {
     language: string;
     licenseHost: string | null;
     userInfo: UserInfo | null;
+    isDemoShop: boolean;
+    demoShopInformation: DemoShopInformation | null;
     success: boolean;
     currentRoute: string;
     currentRouteQuery: LocationQuery;
@@ -301,7 +304,11 @@ export class ExtensionStoreChannelService {
     }
 
     private async handleHandshake(data: HandshakeActionData): Promise<StoreContext> {
-        const extensions = await this.extensionStoreActionService.getMyExtensions();
+        const contextStore = extensionStoreContextStore();
+        const [extensions, { isDemoShop, demoShopInformation }] = await Promise.all([
+            this.extensionStoreActionService.getMyExtensions(),
+            contextStore.loadDemoShopStatus(),
+        ]);
         const owningExtensions = extensions.filter(extension => !!extension.storeLicense)
             .map((extension) => ({
                 name: extension.name,
@@ -310,7 +317,6 @@ export class ExtensionStoreChannelService {
 
         await this.shopwareExtensionService.checkLogin();
 
-        const contextStore = extensionStoreContextStore();
         const licenseHost = await contextStore.loadLicenseHost();
         const shopwareVersion = Shopware.Context.app.config.version ?? '';
         const rawLocale: unknown = Shopware.Store.get('session')?.currentLocale;
@@ -331,6 +337,8 @@ export class ExtensionStoreChannelService {
             language: language,
             licenseHost,
             userInfo: userInfo,
+            isDemoShop,
+            demoShopInformation,
             success: true,
             currentRoute: currentRoute,
             currentRouteQuery: currentRouteQuery,

--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-demo-shop.service.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-demo-shop.service.ts
@@ -1,0 +1,19 @@
+import type { LoginService } from 'src/core/service/login.service';
+import type { AxiosInstance } from 'axios';
+import type { DemoShopStatus } from '../types/extension-store-demo-shop.types';
+
+const { ApiService } = Shopware.Classes;
+
+export default class ExtensionStoreDemoShopService extends ApiService {
+    constructor(httpClient: AxiosInstance, loginService: LoginService, apiEndpoint = 'extension-store') {
+        super(httpClient, loginService, apiEndpoint);
+        this.name = 'extensionStoreDemoShopService';
+    }
+
+    async getDemoShopStatus() {
+        return this.httpClient.get<DemoShopStatus>(
+            `_action/${this.apiEndpoint}/demo-shop-information`,
+            { headers: this.getBasicHeaders() },
+        ).then(ApiService.handleResponse.bind(this));
+    }
+}

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.spec.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.spec.ts
@@ -1,0 +1,88 @@
+import type { DemoShopStatus } from 'SwagExtensionStore/module/sw-extension-store/types/extension-store-demo-shop.types';
+
+const demoShopStatus: DemoShopStatus = {
+    isDemoShop: true,
+    demoShopInformation: {
+        remainingDays: 5,
+        expirationDate: '2099-12-31',
+        accountLink: 'https://account.shopware.com/shops/demoshops/1',
+        contact: { firstName: 'John', lastName: 'Doe' },
+    },
+};
+
+describe('extension-store-context.store', () => {
+    const getDemoShopStatus = jest.fn();
+    let serviceSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    async function getStore() {
+        // Start each test with a fresh store and no cached status
+        Shopware.Store.unregister('extensionStoreContext' as never);
+        jest.resetModules();
+        const storeModule = await import('./extension-store-context.store');
+
+        return storeModule.default();
+    }
+
+    beforeEach(() => {
+        getDemoShopStatus.mockReset();
+        serviceSpy = jest.spyOn(Shopware, 'Service').mockImplementation(((name: string) => {
+            if (name === 'extensionStoreDemoShopService') {
+                return { getDemoShopStatus };
+            }
+
+            throw new Error(`Unexpected service: ${name}`);
+        }) as typeof Shopware.Service);
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        serviceSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    it('loads and caches the demo shop status', async () => {
+        getDemoShopStatus.mockResolvedValue(demoShopStatus);
+        const store = await getStore();
+
+        await expect(store.loadDemoShopStatus()).resolves.toEqual(demoShopStatus);
+
+        expect(store.demoShopStatus).toEqual(demoShopStatus);
+
+        await expect(store.loadDemoShopStatus()).resolves.toEqual(demoShopStatus);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates concurrent requests', async () => {
+        getDemoShopStatus.mockResolvedValue(demoShopStatus);
+        const store = await getStore();
+
+        const [first, second] = await Promise.all([
+            store.loadDemoShopStatus(),
+            store.loadDemoShopStatus(),
+        ]);
+
+        expect(first).toEqual(demoShopStatus);
+        expect(second).toEqual(demoShopStatus);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a regular shop on errors without caching the result', async () => {
+        getDemoShopStatus.mockRejectedValueOnce(new Error('sbp unreachable'));
+        getDemoShopStatus.mockResolvedValueOnce(demoShopStatus);
+        const store = await getStore();
+
+        await expect(store.loadDemoShopStatus()).resolves.toEqual({
+            isDemoShop: false,
+            demoShopInformation: null,
+        });
+
+        expect(store.demoShopStatus).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        // The next call retries instead of caching the fallback.
+        await expect(store.loadDemoShopStatus()).resolves.toEqual(demoShopStatus);
+        expect(store.demoShopStatus).toEqual(demoShopStatus);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.ts
@@ -1,7 +1,10 @@
+import type { DemoShopStatus } from '../types/extension-store-demo-shop.types';
+
 export type ExtensionStoreContextState = {
     licenseHost: string | null;
     skyBridgeStoreVersion: string | null;
     iframeUrl: string | null;
+    demoShopStatus: DemoShopStatus | null;
 };
 
 const FALLBACK_IFRAME_URL = 'https://sky-bridge-store.production.shopware.in';
@@ -10,12 +13,14 @@ const isLoggedIn = () => Shopware.Store.get('shopwareExtensions').userInfo !== n
 
 let iframeUrlLoadPromise: Promise<string> | null = null;
 let licenseHostLoadPromise: Promise<string | null> | null = null;
+let demoShopStatusLoadPromise: Promise<DemoShopStatus> | null = null;
 
 export default Shopware.Store.register('extensionStoreContext', {
     state: (): ExtensionStoreContextState => ({
         licenseHost: null,
         skyBridgeStoreVersion: null,
         iframeUrl: null,
+        demoShopStatus: null,
     }),
     actions: {
         loadLicenseHost(): Promise<string | null> {
@@ -49,6 +54,32 @@ export default Shopware.Store.register('extensionStoreContext', {
                 });
 
             return licenseHostLoadPromise;
+        },
+        loadDemoShopStatus(): Promise<DemoShopStatus> {
+            // The demo shop status cannot change during an admin session, so it is only requested once
+            if (this.demoShopStatus) {
+                return Promise.resolve(this.demoShopStatus);
+            }
+
+            if (demoShopStatusLoadPromise) {
+                return demoShopStatusLoadPromise;
+            }
+
+            demoShopStatusLoadPromise = Shopware.Service('extensionStoreDemoShopService')
+                .getDemoShopStatus()
+                .then((demoShopStatus: DemoShopStatus) => {
+                    this.demoShopStatus = demoShopStatus;
+
+                    return demoShopStatus;
+                })
+                .catch((error: unknown) => {
+                    console.warn('Failed to load the demo shop status. Assuming a regular shop.', error);
+                    demoShopStatusLoadPromise = null;
+
+                    return { isDemoShop: false as const, demoShopInformation: null };
+                });
+
+            return demoShopStatusLoadPromise;
         },
         updateSkyBridgeStoreVersion(version: string): void {
             this.skyBridgeStoreVersion = version;

--- a/src/Resources/app/administration/src/module/sw-extension-store/types/extension-store-demo-shop.types.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/types/extension-store-demo-shop.types.ts
@@ -1,0 +1,21 @@
+type DemoShopContact = {
+    firstName: string;
+    lastName: string;
+};
+
+type DemoShopInformation = {
+    remainingDays: number;
+    expirationDate: string;
+    accountLink: string;
+    contact: DemoShopContact | null;
+};
+
+type DemoShopStatus =
+    | { isDemoShop: true; demoShopInformation: DemoShopInformation }
+    | { isDemoShop: false; demoShopInformation: null };
+
+export type {
+    DemoShopContact,
+    DemoShopInformation,
+    DemoShopStatus,
+};

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,6 +9,7 @@
             <parameter key="create_basket">/swplatform/extensionstore/baskets</parameter>
             <parameter key="order_basket">/swplatform/extensionstore/orders</parameter>
             <parameter key="payment_means">/swplatform/extensionstore/paymentmeans</parameter>
+            <parameter key="demo_shop_information">/swplatform/demoinfo</parameter>
             <parameter key="iap_create_basket">/swplatform/inappfeatures/baskets</parameter>
             <parameter key="iap_order_basket">/swplatform/inappfeatures/orders</parameter>
             <parameter key="iap_list">/swplatform/extensionstore/extensions/%s/inappfeatures</parameter>
@@ -29,6 +30,10 @@
             <argument type="service" id="app.repository"/>
         </service>
 
+        <service id="SwagExtensionStore\Controller\DemoShopController" public="true">
+            <argument type="service" id="SwagExtensionStore\Services\DemoShopService"/>
+        </service>
+
         <!-- Services -->
         <service id="SwagExtensionStore\Services\LicenseService">
             <argument type="service" id="SwagExtensionStore\Services\StoreClient"/>
@@ -38,6 +43,11 @@
             <argument>%swag_extension_store.endpoints%</argument>
             <argument type="service" id="Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider"/>
             <argument type="service" id="shopware.store_client"/>
+        </service>
+
+        <service id="SwagExtensionStore\Services\DemoShopService">
+            <argument type="service" id="SwagExtensionStore\Services\StoreClient"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
         </service>
 
         <service id="SwagExtensionStore\Services\InAppPurchasesService">

--- a/src/Services/DemoShopService.php
+++ b/src/Services/DemoShopService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Services;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use SwagExtensionStore\Struct\DemoShopInformationStruct;
+
+#[Package('checkout')]
+class DemoShopService
+{
+    public function __construct(
+        private readonly StoreClient $client,
+        private readonly SystemConfigService $systemConfigService,
+    ) {
+    }
+
+    public function getDemoShopInformation(Context $context): ?DemoShopInformationStruct
+    {
+        // A demo shop is always provisioned with SBP credentials, so without
+        // a shop secret this installation cannot be a demo shop.
+        if ($this->systemConfigService->getString(StoreRequestOptionsProvider::CONFIG_KEY_STORE_SHOP_SECRET) === '') {
+            return null;
+        }
+
+        return $this->client->getDemoShopInformation($context);
+    }
+}

--- a/src/Services/StoreClient.php
+++ b/src/Services/StoreClient.php
@@ -11,16 +11,19 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\AbstractStoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Struct\CartStruct;
 use SwagExtensionStore\Exception\ExtensionStoreException;
+use SwagExtensionStore\Struct\DemoShopInformationStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCollection;
 use SwagExtensionStore\Struct\InAppPurchaseStruct;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @phpstan-type SbpEndpoints array<string, string>
  * @phpstan-type PaymentMethod array{id: positive-int, type: 'paypal'|'creditCard'|'directDebit', label: string, default: bool}
  *
+ * @phpstan-import-type DemoShopInformation from DemoShopInformationStruct
  * @phpstan-import-type InAppPurchaseCartItem from InAppPurchaseCartPositionStruct
  */
 #[Package('checkout')]
@@ -99,6 +102,31 @@ class StoreClient
         } catch (ClientException $e) {
             throw ExtensionStoreException::createStoreApiExceptionFromClientError($e);
         }
+    }
+
+    public function getDemoShopInformation(Context $context): ?DemoShopInformationStruct
+    {
+        try {
+            $response = $this->client->request(
+                'GET',
+                $this->endpoints['demo_shop_information'],
+                [
+                    'query' => $this->storeRequestOptionsProvider->getDefaultQueryParameters($context),
+                    'headers' => $this->storeRequestOptionsProvider->getAuthenticationHeader($context),
+                ],
+            );
+        } catch (ClientException $e) {
+            throw ExtensionStoreException::createStoreApiExceptionFromClientError($e);
+        }
+
+        if ($response->getStatusCode() === Response::HTTP_NO_CONTENT) {
+            return null;
+        }
+
+        /** @var DemoShopInformation $demoShopInformation */
+        $demoShopInformation = json_decode((string) $response->getBody(), true);
+
+        return DemoShopInformationStruct::fromArray($demoShopInformation);
     }
 
     public function createInAppPurchaseCart(string $extensionName, string $feature, string $variant, Context $context): InAppPurchaseCartStruct

--- a/src/Struct/DemoShopInformationStruct.php
+++ b/src/Struct/DemoShopInformationStruct.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @phpstan-type DemoShopContact array{firstName: string, lastName: string}
+ * @phpstan-type DemoShopInformation array{remainingDays: int, expirationDate: string, accountLink: string, contact: DemoShopContact|null}
+ */
+#[Package('checkout')]
+class DemoShopInformationStruct extends Struct
+{
+    /**
+     * @param DemoShopContact|null $contact
+     */
+    private function __construct(
+        protected int $remainingDays,
+        protected string $expirationDate,
+        protected string $accountLink,
+        protected ?array $contact,
+    ) {
+    }
+
+    /**
+     * @param DemoShopInformation $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['remainingDays'],
+            $data['expirationDate'],
+            $data['accountLink'],
+            $data['contact'],
+        );
+    }
+
+    /**
+     * @return DemoShopInformation
+     */
+    public function toArray(): array
+    {
+        return [
+            'remainingDays' => $this->remainingDays,
+            'expirationDate' => $this->expirationDate,
+            'accountLink' => $this->accountLink,
+            'contact' => $this->contact,
+        ];
+    }
+}

--- a/src/Struct/InAppPurchaseCartPositionStruct.php
+++ b/src/Struct/InAppPurchaseCartPositionStruct.php
@@ -8,8 +8,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 /**
- * @codeCoverageIgnore
- *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePriceModel from InAppPurchasePriceModelStruct
  * @phpstan-import-type InAppPurchaseSubscriptionChange from InAppPurchaseSubscriptionChangeStruct

--- a/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
+++ b/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 /**
- * @codeCoverageIgnore
- *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePendingDowngrade from InAppPurchasePendingDowngradeStruct
  *

--- a/tests/Controller/DemoShopControllerTest.php
+++ b/tests/Controller/DemoShopControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use SwagExtensionStore\Controller\DemoShopController;
+use SwagExtensionStore\Services\DemoShopService;
+use SwagExtensionStore\Struct\DemoShopInformationStruct;
+
+class DemoShopControllerTest extends TestCase
+{
+    public function testItReturnsDemoShopInformation(): void
+    {
+        $information = DemoShopInformationStruct::fromArray([
+            'remainingDays' => 5,
+            'expirationDate' => '2099-12-31',
+            'accountLink' => 'https://account.shopware.com/shops/demoshops/1',
+            'contact' => null,
+        ]);
+        $service = static::createStub(DemoShopService::class);
+        $service->method('getDemoShopInformation')->willReturn($information);
+
+        $response = (new DemoShopController($service))->getDemoShopInformation(Context::createDefaultContext());
+
+        static::assertSame([
+            'isDemoShop' => true,
+            'demoShopInformation' => $information->toArray(),
+        ], json_decode((string) $response->getContent(), true));
+    }
+
+    public function testItReturnsRegularShopStatus(): void
+    {
+        $service = static::createStub(DemoShopService::class);
+        $service->method('getDemoShopInformation')->willReturn(null);
+
+        $response = (new DemoShopController($service))->getDemoShopInformation(Context::createDefaultContext());
+
+        static::assertSame([
+            'isDemoShop' => false,
+            'demoShopInformation' => null,
+        ], json_decode((string) $response->getContent(), true));
+    }
+}

--- a/tests/Services/DemoShopServiceTest.php
+++ b/tests/Services/DemoShopServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use SwagExtensionStore\Services\DemoShopService;
+use SwagExtensionStore\Services\StoreClient;
+use SwagExtensionStore\Struct\DemoShopInformationStruct;
+
+class DemoShopServiceTest extends TestCase
+{
+    public function testItDelegatesDemoShopDetectionToTheStoreClient(): void
+    {
+        $context = Context::createDefaultContext();
+        $information = DemoShopInformationStruct::fromArray([
+            'remainingDays' => 5,
+            'expirationDate' => '2099-12-31',
+            'accountLink' => 'https://account.shopware.com/shops/demoshops/1',
+            'contact' => null,
+        ]);
+        $client = $this->createMock(StoreClient::class);
+        $client->expects(static::once())
+            ->method('getDemoShopInformation')
+            ->with($context)
+            ->willReturn($information);
+
+        $result = (new DemoShopService($client, $this->createSystemConfigService('shop-s3cret')))
+            ->getDemoShopInformation($context);
+
+        static::assertSame($information, $result);
+    }
+
+    public function testItSkipsTheStoreRequestWhenTheShopSecretIsMissing(): void
+    {
+        $client = $this->createMock(StoreClient::class);
+        $client->expects(static::never())
+            ->method('getDemoShopInformation');
+
+        $result = (new DemoShopService($client, $this->createSystemConfigService('')))
+            ->getDemoShopInformation(Context::createDefaultContext());
+
+        static::assertNull($result);
+    }
+
+    private function createSystemConfigService(string $shopSecret): SystemConfigService
+    {
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->method('getString')
+            ->with(StoreRequestOptionsProvider::CONFIG_KEY_STORE_SHOP_SECRET)
+            ->willReturn($shopSecret);
+
+        return $systemConfigService;
+    }
+}

--- a/tests/Services/StoreClientTest.php
+++ b/tests/Services/StoreClientTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Store\Struct\CartStruct;
 use Shopware\Core\Framework\Test\Store\StoreClientBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use SwagExtensionStore\Services\StoreClient;
+use SwagExtensionStore\Struct\DemoShopInformationStruct;
 use SwagExtensionStore\Struct\InAppPurchaseCartPositionStruct;
 
 /**
@@ -85,6 +86,47 @@ class StoreClientTest extends TestCase
 
         $this->expectException(StoreApiException::class);
         $this->storeClient->availablePaymentMeans($this->context);
+    }
+
+    public function testGetDemoShopInformation(): void
+    {
+        $this->getStoreRequestHandler()->append(new Response(200, [], (string) json_encode([
+            'remainingDays' => 5,
+            'expirationDate' => '2099-12-31',
+            'accountLink' => 'https://account.shopware.com/shops/demoshops/1',
+            'contact' => [
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+            ],
+        ])));
+
+        $demoShopInformation = $this->storeClient->getDemoShopInformation($this->context);
+
+        static::assertInstanceOf(DemoShopInformationStruct::class, $demoShopInformation);
+        static::assertSame([
+            'remainingDays' => 5,
+            'expirationDate' => '2099-12-31',
+            'accountLink' => 'https://account.shopware.com/shops/demoshops/1',
+            'contact' => [
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+            ],
+        ], $demoShopInformation->toArray());
+    }
+
+    public function testGetDemoShopInformationReturnsNullForAStandardShop(): void
+    {
+        $this->getStoreRequestHandler()->append(new Response(204));
+
+        static::assertNull($this->storeClient->getDemoShopInformation($this->context));
+    }
+
+    public function testGetDemoShopInformationPropagatesApiErrors(): void
+    {
+        $this->getStoreRequestHandler()->append(new Response(401, [], '{}'));
+
+        $this->expectException(StoreApiException::class);
+        $this->storeClient->getDemoShopInformation($this->context);
     }
 
     public function testCreateInAppPurchaseCartException(): void


### PR DESCRIPTION
## Why

The Admin Store has to know whether the current installation is a CE demo store so upcoming tickets can adjust storefront views, show demo-specific checkout information and restrict features. The platform is the only authoritative source for this: a demo store is indistinguishable from a regular one by domain, template or credentials.

## What

**PHP**

- `StoreClient::getDemoShopInformation()` calls `GET /swplatform/demoinfo` with the existing `AbstractStoreRequestOptionsProvider`, so the licence host and shop secret never leave the server. `204 No Content` means the shop is not a demo shop, a body is hydrated into `DemoShopInformationStruct`.
- `DemoShopService` skips the request entirely when `core.store.shopSecret` is empty: a demo shop is always provisioned with credentials, so an unregistered shop cannot be one and would only produce a failing request on every store visit.
- `DemoShopController` exposes `GET /api/_action/extension-store/demo-shop-information` returning `{ isDemoShop, demoShopInformation }`.

**Administration**

- `ExtensionStoreDemoShopService` calls that route; `extensionStoreContext` caches the result for the session, because the status cannot change while the admin is open.
- The handshake sends `isDemoShop` and `demoShopInformation` in the store context. It runs alongside `getMyExtensions()` so it adds no round trip to the handshake, which has a 7 second SDK timeout.
- A failing request logs a warning and reports a regular shop rather than breaking the handshake. This only affects what the store displays; the platform enforces the demo rules server-side (ECTO-2720, ECTO-2722).

Requires the platform side of ECTO-2855 (SBP PR 3520) for the `204` answer. Against an older platform a registered regular shop still resolves to `isDemoShop: false`, just via the error path. The Sky Bridge Store side reads the two new fields and is a separate change.