### PR TITLE
ECTO-2855 - detect demo shops by the demo shop bundle

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,10 +19,6 @@ parameters:
             message: '#Service ".*" is private#'
             path: tests
 
-        -
-            message: '#Call to deprecated method set\(\) of class Shopware\\Core\\System\\SystemConfig\\SystemConfigService#'
-            path: tests
-
 rules:
     # Shopware core rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/src/Controller/DemoShopController.php
+++ b/src/Controller/DemoShopController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Controller;
+
+use Shopware\Core\Framework\Log\Package;
+use SwagExtensionStore\Services\DemoShopService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[Route(defaults: ['_routeScope' => ['api'], '_acl' => ['system.extension_store']])]
+class DemoShopController
+{
+    public function __construct(private readonly DemoShopService $demoShopService)
+    {
+    }
+
+    #[Route('/api/_action/extension-store/demo-shop-status', name: 'api.extension.demo-shop-status', methods: ['GET'])]
+    public function getDemoShopStatus(): JsonResponse
+    {
+        return new JsonResponse([
+            'isDemoShop' => $this->demoShopService->isDemoShop(),
+        ]);
+    }
+}

--- a/src/Resources/app/administration/src/global.types.ts
+++ b/src/Resources/app/administration/src/global.types.ts
@@ -6,6 +6,8 @@ import type ExtensionStorePreferencesService
 import type {
     ExtensionStoreChannelService,
 } from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-channel.service';
+import type ExtensionStoreDemoShopService
+    from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-demo-shop.service';
 
 declare global {
     type PropType<T> = TPropType<T>;
@@ -14,6 +16,7 @@ declare global {
         inAppPurchasesService: InAppPurchasesService;
         extensionStoreChannelService: ExtensionStoreChannelService;
         extensionStorePreferencesService: ExtensionStorePreferencesService;
+        extensionStoreDemoShopService: ExtensionStoreDemoShopService;
     }
 
     type ErrorResponse = AxiosError<{ errors: Array<ShopwareHttpError & { apiCode: string }> }>;

--- a/src/Resources/app/administration/src/module/sw-extension-store/index.js
+++ b/src/Resources/app/administration/src/module/sw-extension-store/index.js
@@ -1,4 +1,5 @@
 import ExtensionLicenseService from './service/extension-store-licenses.service';
+import ExtensionStoreDemoShopService from './service/extension-store-demo-shop.service';
 import {
     ExtensionStoreChannelService,
 } from 'SwagExtensionStore/module/sw-extension-store/service/extension-store-channel.service';
@@ -27,6 +28,13 @@ Shopware.Application.addServiceProvider('extensionStoreChannelService', () => {
 
 Shopware.Application.addServiceProvider('extensionStoreLicensesService', () => {
     return new ExtensionLicenseService(
+        Shopware.Application.getContainer('init').httpClient,
+        Shopware.Service('loginService'),
+    );
+});
+
+Shopware.Application.addServiceProvider('extensionStoreDemoShopService', () => {
+    return new ExtensionStoreDemoShopService(
         Shopware.Application.getContainer('init').httpClient,
         Shopware.Service('loginService'),
     );

--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-channel.service.ts
@@ -66,6 +66,7 @@ type StoreContext = {
     language: string;
     licenseHost: string | null;
     userInfo: UserInfo | null;
+    isDemoShop: boolean;
     success: boolean;
     currentRoute: string;
     currentRouteQuery: LocationQuery;
@@ -301,7 +302,11 @@ export class ExtensionStoreChannelService {
     }
 
     private async handleHandshake(data: HandshakeActionData): Promise<StoreContext> {
-        const extensions = await this.extensionStoreActionService.getMyExtensions();
+        const contextStore = extensionStoreContextStore();
+        const [extensions, isDemoShop] = await Promise.all([
+            this.extensionStoreActionService.getMyExtensions(),
+            contextStore.loadIsDemoShop(),
+        ]);
         const owningExtensions = extensions.filter(extension => !!extension.storeLicense)
             .map((extension) => ({
                 name: extension.name,
@@ -310,7 +315,6 @@ export class ExtensionStoreChannelService {
 
         await this.shopwareExtensionService.checkLogin();
 
-        const contextStore = extensionStoreContextStore();
         const licenseHost = await contextStore.loadLicenseHost();
         const shopwareVersion = Shopware.Context.app.config.version ?? '';
         const rawLocale: unknown = Shopware.Store.get('session')?.currentLocale;
@@ -331,6 +335,7 @@ export class ExtensionStoreChannelService {
             language: language,
             licenseHost,
             userInfo: userInfo,
+            isDemoShop,
             success: true,
             currentRoute: currentRoute,
             currentRouteQuery: currentRouteQuery,

--- a/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-demo-shop.service.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/service/extension-store-demo-shop.service.ts
@@ -1,0 +1,22 @@
+import type { LoginService } from 'src/core/service/login.service';
+import type { AxiosInstance } from 'axios';
+
+const { ApiService } = Shopware.Classes;
+
+export interface DemoShopStatus {
+    isDemoShop: boolean;
+}
+
+export default class ExtensionStoreDemoShopService extends ApiService {
+    constructor(httpClient: AxiosInstance, loginService: LoginService, apiEndpoint = 'extension-store') {
+        super(httpClient, loginService, apiEndpoint);
+        this.name = 'extensionStoreDemoShopService';
+    }
+
+    async getDemoShopStatus() {
+        return this.httpClient.get<DemoShopStatus>(
+            `_action/${this.apiEndpoint}/demo-shop-status`,
+            { headers: this.getBasicHeaders() },
+        ).then(ApiService.handleResponse.bind(this));
+    }
+}

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.spec.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.spec.ts
@@ -1,0 +1,72 @@
+
+describe('extension-store-context.store', () => {
+    const getDemoShopStatus = jest.fn();
+    let serviceSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    async function getStore() {
+        // Start each test with a fresh store and no cached status
+        Shopware.Store.unregister('extensionStoreContext' as never);
+        jest.resetModules();
+        const storeModule = await import('./extension-store-context.store');
+
+        return storeModule.default();
+    }
+
+    beforeEach(() => {
+        getDemoShopStatus.mockReset();
+        serviceSpy = jest.spyOn(Shopware, 'Service').mockImplementation(((name: string) => {
+            if (name === 'extensionStoreDemoShopService') {
+                return { getDemoShopStatus };
+            }
+
+            throw new Error(`Unexpected service: ${name}`);
+        }) as typeof Shopware.Service);
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        serviceSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    it('loads and caches the demo shop status', async () => {
+        getDemoShopStatus.mockResolvedValue({ isDemoShop: true });
+        const store = await getStore();
+
+        await expect(store.loadIsDemoShop()).resolves.toBe(true);
+
+        expect(store.isDemoShop).toBe(true);
+
+        await expect(store.loadIsDemoShop()).resolves.toBe(true);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates concurrent requests', async () => {
+        getDemoShopStatus.mockResolvedValue({ isDemoShop: true });
+        const store = await getStore();
+
+        const [first, second] = await Promise.all([
+            store.loadIsDemoShop(),
+            store.loadIsDemoShop(),
+        ]);
+
+        expect(first).toBe(true);
+        expect(second).toBe(true);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a regular shop on errors without caching the result', async () => {
+        getDemoShopStatus.mockRejectedValueOnce(new Error('endpoint unavailable'));
+        getDemoShopStatus.mockResolvedValueOnce({ isDemoShop: true });
+        const store = await getStore();
+
+        await expect(store.loadIsDemoShop()).resolves.toBe(false);
+
+        expect(store.isDemoShop).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        await expect(store.loadIsDemoShop()).resolves.toBe(true);
+        expect(getDemoShopStatus).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.ts
+++ b/src/Resources/app/administration/src/module/sw-extension-store/store/extension-store-context.store.ts
@@ -1,7 +1,10 @@
+import type { DemoShopStatus } from '../service/extension-store-demo-shop.service';
+
 export type ExtensionStoreContextState = {
     licenseHost: string | null;
     skyBridgeStoreVersion: string | null;
     iframeUrl: string | null;
+    isDemoShop: boolean | null;
 };
 
 const FALLBACK_IFRAME_URL = 'https://sky-bridge-store.production.shopware.in';
@@ -10,12 +13,14 @@ const isLoggedIn = () => Shopware.Store.get('shopwareExtensions').userInfo !== n
 
 let iframeUrlLoadPromise: Promise<string> | null = null;
 let licenseHostLoadPromise: Promise<string | null> | null = null;
+let isDemoShopLoadPromise: Promise<boolean> | null = null;
 
 export default Shopware.Store.register('extensionStoreContext', {
     state: (): ExtensionStoreContextState => ({
         licenseHost: null,
         skyBridgeStoreVersion: null,
         iframeUrl: null,
+        isDemoShop: null,
     }),
     actions: {
         loadLicenseHost(): Promise<string | null> {
@@ -49,6 +54,32 @@ export default Shopware.Store.register('extensionStoreContext', {
                 });
 
             return licenseHostLoadPromise;
+        },
+        loadIsDemoShop(): Promise<boolean> {
+            // Bundles cannot change while the admin is open, so it is only requested once
+            if (this.isDemoShop !== null) {
+                return Promise.resolve(this.isDemoShop);
+            }
+
+            if (isDemoShopLoadPromise) {
+                return isDemoShopLoadPromise;
+            }
+
+            isDemoShopLoadPromise = Shopware.Service('extensionStoreDemoShopService')
+                .getDemoShopStatus()
+                .then(({ isDemoShop }: DemoShopStatus) => {
+                    this.isDemoShop = isDemoShop;
+
+                    return isDemoShop;
+                })
+                .catch((error: unknown) => {
+                    console.warn('Failed to load the demo shop status. Assuming a regular shop.', error);
+                    isDemoShopLoadPromise = null;
+
+                    return false;
+                });
+
+            return isDemoShopLoadPromise;
         },
         updateSkyBridgeStoreVersion(version: string): void {
             this.skyBridgeStoreVersion = version;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -29,9 +29,17 @@
             <argument type="service" id="app.repository"/>
         </service>
 
+        <service id="SwagExtensionStore\Controller\DemoShopController" public="true">
+            <argument type="service" id="SwagExtensionStore\Services\DemoShopService"/>
+        </service>
+
         <!-- Services -->
         <service id="SwagExtensionStore\Services\LicenseService">
             <argument type="service" id="SwagExtensionStore\Services\StoreClient"/>
+        </service>
+
+        <service id="SwagExtensionStore\Services\DemoShopService">
+            <argument>%kernel.bundles%</argument>
         </service>
 
         <service id="SwagExtensionStore\Services\StoreClient">

--- a/src/Services/DemoShopService.php
+++ b/src/Services/DemoShopService.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Services;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class DemoShopService
+{
+    /**
+     * Name of the bundle that is only shipped with a CE demo shop. Has to match the
+     * bundle name the demo instances are provisioned with.
+     */
+    public const DEMO_SHOP_BUNDLE_NAME = 'DemoShopBundleNamePlaceholder';
+
+    /**
+     * @param array<string, class-string> $kernelBundles bundle name to class, from %kernel.bundles%
+     */
+    public function __construct(private readonly array $kernelBundles)
+    {
+    }
+
+    public function isDemoShop(): bool
+    {
+        return isset($this->kernelBundles[self::DEMO_SHOP_BUNDLE_NAME]);
+    }
+}

--- a/src/Struct/InAppPurchaseCartPositionStruct.php
+++ b/src/Struct/InAppPurchaseCartPositionStruct.php
@@ -8,8 +8,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 /**
- * @codeCoverageIgnore
- *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePriceModel from InAppPurchasePriceModelStruct
  * @phpstan-import-type InAppPurchaseSubscriptionChange from InAppPurchaseSubscriptionChangeStruct

--- a/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
+++ b/src/Struct/InAppPurchaseSubscriptionChangeStruct.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 /**
- * @codeCoverageIgnore
- *
  * @phpstan-import-type InAppPurchase from InAppPurchaseStruct
  * @phpstan-import-type InAppPurchasePendingDowngrade from InAppPurchasePendingDowngradeStruct
  *

--- a/tests/Controller/DemoShopControllerTest.php
+++ b/tests/Controller/DemoShopControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use SwagExtensionStore\Controller\DemoShopController;
+use SwagExtensionStore\Services\DemoShopService;
+
+class DemoShopControllerTest extends TestCase
+{
+    public function testItReturnsDemoShopStatus(): void
+    {
+        $service = static::createStub(DemoShopService::class);
+        $service->method('isDemoShop')->willReturn(true);
+
+        $response = (new DemoShopController($service))->getDemoShopStatus();
+
+        static::assertSame(['isDemoShop' => true], json_decode((string) $response->getContent(), true));
+    }
+
+    public function testItReturnsRegularShopStatus(): void
+    {
+        $service = static::createStub(DemoShopService::class);
+        $service->method('isDemoShop')->willReturn(false);
+
+        $response = (new DemoShopController($service))->getDemoShopStatus();
+
+        static::assertSame(['isDemoShop' => false], json_decode((string) $response->getContent(), true));
+    }
+}

--- a/tests/Services/DemoShopServiceTest.php
+++ b/tests/Services/DemoShopServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagExtensionStore\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use SwagExtensionStore\Services\DemoShopService;
+
+class DemoShopServiceTest extends TestCase
+{
+    public function testItDetectsADemoShopByTheDemoShopBundle(): void
+    {
+        $service = new DemoShopService([
+            'FrameworkBundle' => 'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'SwagExtensionStore' => 'SwagExtensionStore\SwagExtensionStore',
+            DemoShopService::DEMO_SHOP_BUNDLE_NAME => 'Vendor\DemoShop\DemoShopBundleNamePlaceholder',
+        ]);
+
+        static::assertTrue($service->isDemoShop());
+    }
+
+    public function testItDetectsARegularShopWithoutTheDemoShopBundle(): void
+    {
+        $service = new DemoShopService([
+            'FrameworkBundle' => 'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'SwagExtensionStore' => 'SwagExtensionStore\SwagExtensionStore',
+        ]);
+
+        static::assertFalse($service->isDemoShop());
+    }
+
+    public function testItDetectsARegularShopWithoutAnyBundle(): void
+    {
+        static::assertFalse((new DemoShopService([]))->isDemoShop());
+    }
+}


### PR DESCRIPTION
## Why

Alternative to PR #194, which reads the demo shop state from the platform. CE demo instances ship a dedicated bundle for demo specific admin behaviour, so the presence of that bundle already identifies the shop as a demo shop — no platform request needed.

## What

- `DemoShopService` receives Symfony's `%kernel.bundles%` and checks whether the demo shop bundle is registered. That covers every way the bundle can arrive: `config/bundles.php`, a composer package, or a Shopware plugin (the latter only while it is active).
- `DemoShopController` exposes it as `GET /api/_action/extension-store/demo-shop-status` returning `{ isDemoShop }`. The endpoint exists because the bundle list is only known in PHP.
- The administration caches the answer for the session, alongside `licenseHost` and `iframeUrl`, and the handshake passes `isDemoShop` into the Admin Store iframe. It runs next to `getMyExtensions()` so it adds no round trip to the handshake.
- A failing request logs a warning and reports a regular shop rather than breaking the handshake.

Compared to #194 this drops the store client method, the struct and the response fixture, and it needs no platform change at all.

## Trade-offs

- **Only the flag.** `remainingDays`, `expirationDate`, `accountLink` and `contact` cannot come from bundle presence. If the Admin Store has to display them, they still need `/swplatform/demoinfo` (PR #194) or an API from the bundle itself.
- **Not authoritative.** The signal is as trustworthy as the provisioning: the bundle must be present in demo instances only. The platform still enforces the demo rules server-side, so this only drives what the store displays.
- **`DEMO_SHOP_BUNDLE_NAME` is a placeholder** until the bundle authors confirm the real name. A mismatch degrades silently to "regular shop".

## Notes

The Sky Bridge Store side is a separate change and is **not** interchangeable with #194: this variant sends `isDemoShop` without an information object, which the paired validation proposed in #194 would reject.

The last three files (`phpstan.neon.dist`, the two IAP structs) are unrelated pre-existing fixes, also contained in #194: an ignore pattern unmatched since EXS-92 and two `@codeCoverageIgnore` annotations on classes that contain logic. Without them static analysis fails for any pull request touching PHP.