### PR TITLE
feat: Move analysis promotion to other position

### DIFF
--- a/src/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig
+++ b/src/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig
@@ -1,5 +1,5 @@
-{% block sw_dashboard_index_content_intro_card %}
-    {% parent %}
+{% block sw_dashboard_index_content_info_grid %}
     <sw-payments-dashboard-promotion-card />
     <sw-dashboard-statistics-promotion-card />
+    {% parent %}
 {% endblock %}


### PR DESCRIPTION
Move promotion under dashboard's "before content" components

| Before | After |
|---|---|
| <img width="381" height="657" alt="Screenshot 2026-08-20 at 10 37 11" src="https://github.com/user-attachments/assets/1af99885-d299-432f-99b6-eb9cd4b25f68" /> | <img width="389" height="643" alt="Screenshot 2026-08-20 at 10 22 39" src="https://github.com/user-attachments/assets/3c49d5f1-ce5c-4064-9c5b-4f6da87f5b95" /> |